### PR TITLE
Document config options for Qt console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist
 _build
 docs/man/*.gz
 docs/source/api/generated
-docs/source/config/options
+docs/source/config_options.rst
 docs/source/interactive/magics-generated.txt
 docs/gh-pages
 jupyter_notebook/notebook/static/mathjax

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,11 +50,16 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf source/config_options.rst
 
-html:
+html: source/config_options.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+source/config_options.rst:
+	python3 autogen_config.py
+	@echo "Created docs for config options"
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from qtconsole.qtconsoleapp import JupyterQtConsoleApp
+
+header = """\
+Configuration options
+=====================
+
+These options can be set in ``~/.jupyer/jupyter_qtconsole_config.py``, or
+at the command line when you start it.
+"""
+
+with open("source/config_options.rst", 'w') as f:
+    f.write(header)
+    f.write(JupyterQtConsoleApp().document_config_options())

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,11 @@ To start the Qt Console::
 
     $> ipython qtconsole
 
+.. toctree::
+   :maxdepth: 2
+
+   config_options
+
 We now have a version of IPython, using the two-process ZeroMQ Kernel, running in a PyQt_ GUI.  This is a very lightweight widget that
 largely feels like a terminal, but provides a number of enhancements only
 possible in a GUI, such as inline figures, proper multiline editing with syntax


### PR DESCRIPTION
Using the newly merged traitlets machinery for this.

@jdfreder when we finalise this, it's probably worth doing something similar for the notebook docs. It looks like in jupyter/notebook#124, you've generated it and committed the output; this approach automatically generates it when building the docs, which should make things easier when we add or change options.