### PR TITLE
Workaround to generate config docs on RTD

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os.path
 from qtconsole.qtconsoleapp import JupyterQtConsoleApp
 
 header = """\
@@ -10,6 +11,8 @@ These options can be set in ``~/.jupyer/jupyter_qtconsole_config.py``, or
 at the command line when you start it.
 """
 
-with open("source/config_options.rst", 'w') as f:
+destination = os.path.join(os.path.dirname(__file__), 'source/config_options.rst')
+
+with open(destination, 'w') as f:
     f.write(header)
     f.write(JupyterQtConsoleApp().document_config_options())

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,12 @@ exec(compile(open('../../qtconsole/_version.py').read(), '../../qtconsole/_versi
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+if os.environ.get('READTHEDOCS', ''):
+    # Readthedocs doesn't run our Makefile, so we do this to force it to generate
+    # the config docs.
+    with open('../autogen_config.py') as f:
+        exec(compile(f.read(), '../autogen_config.py', 'exec'), {})
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,17 @@ exec(compile(open('../../qtconsole/_version.py').read(), '../../qtconsole/_versi
 #sys.path.insert(0, os.path.abspath('.'))
 
 if os.environ.get('READTHEDOCS', ''):
+    # Mock out PyQt4 so we can import the Qt console code
+    from unittest.mock import MagicMock
+
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+                return Mock()
+
+    MOCK_MODULES = ['PyQt4']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
     # Readthedocs doesn't run our Makefile, so we do this to force it to generate
     # the config docs.
     with open('../autogen_config.py') as f:


### PR DESCRIPTION
Including mocking out PyQt4 so it can import the Qt console files.

Ping @jdfreder 