### PR TITLE
Host built docs on Github pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  gh-pages   clone qtconsole docs in ./gh-pages/ , build doc, autocommit"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -60,6 +61,12 @@ html: source/config_options.rst
 source/config_options.rst:
 	python3 autogen_config.py
 	@echo "Created docs for config options"
+
+gh-pages: clean html
+	# if VERSION is unspecified, it will be dev
+	# For releases, VERSION should be just the major version,
+	# e.g. VERSION=2 make gh-pages
+	python3 gh-pages.py $(VERSION)
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/gh-pages.py
+++ b/docs/gh-pages.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+"""Script to commit the doc build outputs into the github-pages repo.
+
+Use:
+
+  gh-pages.py [tag]
+
+If no tag is given, the current output of 'git describe' is used.  If given,
+that is how the resulting directory will be named.
+
+In practice, you should use either actual clean tags from a current build or
+something like 'current' as a stable URL for the most current version of the """
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+from os import chdir as cd
+from os.path import join as pjoin
+
+from subprocess import Popen, PIPE, CalledProcessError, check_call
+
+#-----------------------------------------------------------------------------
+# Globals
+#-----------------------------------------------------------------------------
+
+pages_dir = 'gh-pages'
+html_dir = 'build/html'
+pdf_dir = 'build/latex'
+pages_repo = 'git@github.com:jupyter/qtconsole.git'
+
+#-----------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------
+def sh(cmd):
+    """Execute command in a subshell, return status code."""
+    return check_call(cmd, shell=True)
+
+
+def sh2(cmd):
+    """Execute command in a subshell, return stdout.
+
+    Stderr is unbuffered from the subshell.x"""
+    p = Popen(cmd, stdout=PIPE, shell=True)
+    out = p.communicate()[0]
+    retcode = p.returncode
+    if retcode:
+        raise CalledProcessError(retcode, cmd)
+    else:
+        return out.rstrip()
+
+
+def sh3(cmd):
+    """Execute command in a subshell, return stdout, stderr
+
+    If anything appears in stderr, print it out to sys.stderr"""
+    p = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = p.communicate()
+    retcode = p.returncode
+    if retcode:
+        raise CalledProcessError(retcode, cmd)
+    else:
+        return out.rstrip(), err.rstrip()
+
+
+def init_repo(path):
+    """clone the gh-pages repo if we haven't already."""
+    sh("git clone %s %s"%(pages_repo, path))
+    here = os.getcwd()
+    cd(path)
+    sh('git checkout gh-pages')
+    cd(here)
+
+#-----------------------------------------------------------------------------
+# Script starts
+#-----------------------------------------------------------------------------
+if __name__ == '__main__':
+    # The tag can be given as a positional argument
+    try:
+        tag = sys.argv[1]
+    except IndexError:
+        tag = "dev"
+    
+    startdir = os.getcwd()
+    if not os.path.exists(pages_dir):
+        # init the repo
+        init_repo(pages_dir)
+    else:
+        # ensure up-to-date before operating
+        cd(pages_dir)
+        sh('git checkout gh-pages')
+        sh('git pull')
+        cd(startdir)
+
+    dest = pjoin(pages_dir, tag)
+
+    # don't `make html` here, because gh-pages already depends on html in Makefile
+    # sh('make html')
+    if tag != 'dev':
+        # only build pdf for non-dev targets
+        #sh2('make pdf')
+        pass
+
+    # This is pretty unforgiving: we unconditionally nuke the destination
+    # directory, and then copy the html tree in there
+    shutil.rmtree(dest, ignore_errors=True)
+    shutil.copytree(html_dir, dest)
+    if tag != 'dev':
+        #shutil.copy(pjoin(pdf_dir, 'ipython.pdf'), pjoin(dest, 'ipython.pdf'))
+        pass
+
+    try:
+        cd(pages_dir)
+        branch = sh2('git rev-parse --abbrev-ref HEAD').strip().decode('ascii', 'replace')
+        if branch != 'gh-pages':
+            e = 'On %r, git branch is %r, MUST be "gh-pages"' % (pages_dir,
+                                                                 branch)
+            raise RuntimeError(e)
+
+        sh('git add -A %s' % tag)
+        sh('git commit -m"Updated doc release: %s"' % tag)
+        print()
+        print('Most recent 3 commits:')
+        sys.stdout.flush()
+        # Need 3 commits in the repo before this will work
+        #sh('git --no-pager log --oneline HEAD~3..')
+    finally:
+        cd(startdir)
+
+    print()
+    print('Now verify the build in: %r' % dest)
+    print("If everything looks good, 'git push'")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,23 +25,6 @@ exec(compile(open('../../qtconsole/_version.py').read(), '../../qtconsole/_versi
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-if os.environ.get('READTHEDOCS', ''):
-    # Mock out PyQt4 so we can import the Qt console code
-    from unittest.mock import MagicMock
-
-    class Mock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-                return Mock()
-
-    MOCK_MODULES = ['qtconsole.qt']
-    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
-    # Readthedocs doesn't run our Makefile, so we do this to force it to generate
-    # the config docs.
-    with open('../autogen_config.py') as f:
-        exec(compile(f.read(), '../autogen_config.py', 'exec'), {})
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
My efforts to mock out Qt on Readthedocs didn't work very well, so I think it's simplest to host these docs on gh-pages instead.

This will be at https://jupyter.github.io/qtconsole/dev/

I copied the gh-pages.py script from IPython, updated the repo and changed it to Python 3. I've commented out the command that tries to get the last 3 commits, because there aren't 3 commits yet, so that fails.