### PR TITLE
execute-on-complete fixes

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -599,10 +599,10 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
             self.input_buffer = source
 
         # Execute the source or show a continuation prompt if it is incomplete.
-        if self.execute_on_complete_input:
+        if interactive and self.execute_on_complete_input:
             complete, indent = self._is_complete(source, interactive)
         else:
-            complete = not interactive
+            complete = True
             indent = ''
         if hidden:
             if complete or not self.execute_on_complete_input:

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -251,7 +251,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             if reply['parent_header'].get('msg_id', None) == msg_id:
                 status = reply['content'].get('status', u'complete')
                 indent = reply['content'].get('indent', u'')
-                return status == u'complete', indent
+                return status != 'incomplete', indent
 
     def _execute(self, source, hidden):
         """ Execute 'source'. If 'hidden', do not show any output.


### PR DESCRIPTION
- execute on invalid (only 'incomplete' should prevent execute)
- fix shift-enter for forced execution, which was being ignored when `execute_on_complete_input=True`, the default case.