### PR TITLE
Warn qtconsole does not support getpass

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1976,7 +1976,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
 
         self._control.moveCursor(QtGui.QTextCursor.End)
 
-    def _readline(self, prompt='', callback=None):
+    def _readline(self, prompt='', callback=None, password=False):
         """ Reads one line of input from the user.
 
         Parameters
@@ -2003,6 +2003,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
                                'is not visible!')
 
         self._reading = True
+        if password:
+            self._show_prompt('Warning: QtConsole does not support password mode, '\
+                              'the text you type will be visible.', newline=True)
         self._show_prompt(prompt, newline=False)
 
         if callback is None:

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -478,7 +478,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         if self._reading:
             self.log.debug("Got second input request, assuming first was interrupted.")
             self._reading = False
-        self._readline(msg['content']['prompt'], callback=callback)
+        self._readline(msg['content']['prompt'], callback=callback, password=msg['content']['password'])
 
     def _kernel_restarted_message(self, died=True):
         msg = "Kernel died, restarting" if died else "Kernel restarting"


### PR DESCRIPTION
Mitigate ipython/ipython#8712

<img width="622" alt="screen shot 2015-08-11 at 09 19 07" src="https://cloud.githubusercontent.com/assets/335567/9203127/0def9ece-400a-11e5-8533-b36464ae8ba3.png">

Not sure we can make the RichWidget show stars, but we could pop-up a password input. 