### PR TITLE
Fix an issue when there are multiple screens

### DIFF
--- a/qtconsole/call_tip_widget.py
+++ b/qtconsole/call_tip_widget.py
@@ -163,7 +163,7 @@ class CallTipWidget(QtGui.QLabel):
 
         vertical = 'bottom'
         horizontal = 'Right'
-        if point.y() + tip_height > screen_rect.height():
+        if point.y() + tip_height > screen_rect.height() + screen_rect.y():
             point_ = text_edit.mapToGlobal(cursor_rect.topRight())
             # If tip is still off screen, check if point is in top or bottom
             # half of screen.
@@ -176,7 +176,7 @@ class CallTipWidget(QtGui.QLabel):
                     vertical = 'top'
             else:
                 vertical = 'top'
-        if point.x() + tip_width > screen_rect.width():
+        if point.x() + tip_width > screen_rect.width() + screen_rect.x():
             point_ = text_edit.mapToGlobal(cursor_rect.topRight())
             # If tip is still off-screen, check if point is in the right or
             # left half of the screen.

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -90,7 +90,8 @@ class CompletionWidget(QtGui.QListWidget):
         point = text_edit.mapToGlobal(point)
         height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
-        if screen_rect.size().height() - point.y() - height < 0:
+        if (screen_rect.size().height() + screen_rect.y() 
+                    - point.y() - height < 0):
             point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
             point.setY(point.y() - height)
         self.move(point)


### PR DESCRIPTION
If there are multiple screens, there completion window and call tips would go out of screen. 