### PR TITLE
Add qtconsole/resources to the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,9 @@ include COPYING.md
 include CONTRIBUTING.md
 include README.md
 
+# Resources
+graft qtconsole/resources
+
 # Documentation
 graft docs
 exclude docs/\#*


### PR DESCRIPTION
The JupyterConsole.svg icon was not included in the pypi package, this includes the relevant directory