### PR TITLE
fix `juptyer qtconsole --generate-config`

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -56,9 +56,9 @@ from traitlets import (
     Dict, Unicode, CBool, Any
 )
 
-from jupyter_core.application import JupyterApp
+from jupyter_core.application import JupyterApp, base_flags, base_aliases
 from jupyter_client.consoleapp import (
-        JupyterConsoleApp, app_aliases, app_flags, flags, aliases
+        JupyterConsoleApp, app_aliases, app_flags,
     )
 
 
@@ -73,8 +73,8 @@ jupyter qtconsole                      # start the qtconsole
 # Aliases and Flags
 #-----------------------------------------------------------------------------
 
-# start with copy of flags
-flags = dict(flags)
+# FIXME: workaround bug in jupyter_client < 4.1 excluding base_flags,aliases
+flags = dict(base_flags)
 qt_flags = {
     'plain' : ({'JupyterQtConsoleApp' : {'plain' : True}},
             "Disable rich text support."),
@@ -90,8 +90,8 @@ qt_flags.update(app_flags)
 # add frontend flags to the full set
 flags.update(qt_flags)
 
-# start with copy of front&backend aliases list
-aliases = dict(aliases)
+# start with copy of base jupyter aliases
+aliases = dict(base_aliases)
 qt_aliases = dict(
     style = 'JupyterWidget.syntax_style',
     stylesheet = 'JupyterQtConsoleApp.stylesheet',
@@ -338,6 +338,8 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         self.init_qt_app()
         super(JupyterQtConsoleApp, self).initialize(argv)
+        if self._dispatching:
+            return
         # handle deprecated renames
         for old_name, new_name in [
             ('IPythonQtConsoleApp', 'JupyterQtConsole'),
@@ -352,6 +354,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         self.init_signal()
 
     def start(self):
+        super(JupyterQtConsoleApp, self).start()
 
         # draw the window
         if self.maximize:
@@ -375,9 +378,7 @@ class IPythonQtConsoleApp(JupyterQtConsoleApp):
 #-----------------------------------------------------------------------------
 
 def main():
-    app = JupyterQtConsoleApp()
-    app.initialize()
-    app.start()
+    JupyterQtConsoleApp.launch_instance()
 
 
 if __name__ == '__main__':

--- a/qtconsole/tests/test_app.py
+++ b/qtconsole/tests/test_app.py
@@ -3,7 +3,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import nose.tools as nt
+import os
+import shutil
+import sys
+import tempfile
+from subprocess import check_output
 
 from traitlets.tests.utils import check_help_all_output
 from ipython_genutils.testing.decorators import skip_if_no_x11
@@ -13,3 +17,14 @@ def test_help_output():
     """jupyter qtconsole --help-all works"""
     check_help_all_output('qtconsole')
 
+@skip_if_no_x11
+def test_generate_config():
+    """jupyter qtconsole --generate-config"""
+    td = tempfile.mkdtemp()
+    try:
+        check_output([sys.executable, '-m', 'qtconsole', '--generate-config'],
+            env={'JUPYTER_CONFIG_DIR': td},
+        )
+        assert os.path.isfile(os.path.join(td, 'jupyter_qtconsole_config.py'))
+    finally:
+        shutil.rmtree(td)


### PR DESCRIPTION
the flag was missing from the flags inherited from jupyter_client

jupyter_client fixes the core of the bug in #71, but this should go in anyway.