### PR TITLE
Fallback to the string printer if the latex printer raises an exception

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -172,8 +172,8 @@ class RichJupyterWidget(RichIPythonWidget):
             elif 'text/latex' in data and latex_to_png:
                 try:
                     self._append_latex(data['text/latex'], True)
-                    self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
                 except Exception:
+                    self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
                     return super(RichJupyterWidget, self)._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -140,9 +140,8 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._pre_image_append(msg, prompt_number)
                 try:
                     self._append_latex(data['text/latex'], True)
-                except Exception as e:
+                except Exception:
                     self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
-                    self.log.error("Failed to render latex: %s" % e)
                     return super(RichJupyterWidget, self)._handle_execute_result(msg)
                 self._append_html(self.output_sep2, True)
             else:
@@ -174,8 +173,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 try:
                     self._append_latex(data['text/latex'], True)
                     self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
-                    self.log.error("Failed to render latex: %s" % e)
-                except Exception as e:
+                except Exception:
                     return super(RichJupyterWidget, self)._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.


### PR DESCRIPTION
Currently it just prints an error and gives an empty png. However, there is a
lot of LaTeX that matplotlib cannot parse, e.g., matrices. This gives a better
user experience for SymPy, which has a text printer that it can fallback
to. SymPy cannot just disable the LaTeX printer because it is desired for the
notebook, and there is no way for it to enable LaTeX just in the notebook, or
change the printer precedence order.

I have left in the debug logging of the error (to the terminal).

Fixes #63. This supersedes #57, although I don't know if it fixes the issue
there.