### PR TITLE
Fix number of columns for ncurses tab completion

### DIFF
--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -37,7 +37,9 @@ def html_tableify(item_matrix, select=None, header=None , footer=None) :
         foot = (u'<tr>'\
             +''.join((u'<td>'+footer+u'</td>')*len(item_matrix[0]))\
             +'</tr>')
-    html = (u'<table class="completion" style="white-space:pre">'+head+(u''.join(html_cols))+foot+u'</table>')
+    html = (u'<table class="completion" style="white-space:pre"'
+            'cellspacing=0>' +
+            head + (u''.join(html_cols)) + foot + u'</table>')
     return html
 
 class SlidingInterval(object): 

--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -302,7 +302,12 @@ class CompletionHtml(QtGui.QWidget):
             return
         self._start_position = cursor.position()
         self._consecutive_tab = 1
-        items_m, ci = text.compute_item_matrix(items, empty=' ')
+        # Calculate the number of characters available.
+        width = self._text_edit.document().textWidth()
+        char_width = QtGui.QFontMetrics(self._console_widget.font).width(' ')
+        displaywidth = int(max(10, (width / char_width) - 1))
+        items_m, ci = text.compute_item_matrix(items, empty=' ',
+                                               displaywidth=displaywidth)
         self._sliding_interval = SlidingInterval(len(items_m)-1)
 
         self._items = items_m

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1527,7 +1527,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
         The formatted string.
         """
         # Calculate the number of characters available.
-        width = self._control.viewport().width()
+        width = self._control.document().textWidth()
         char_width = QtGui.QFontMetrics(self.font).width(' ')
         displaywidth = max(10, (width / char_width) - 1)
 


### PR DESCRIPTION
Previously the calculation for how to lay out the tab-completion suggestions just assumed a display width of 80 characters. This fixes it to use the correct width.

Fixes #84.