### PR TITLE
Fix droplist completer focus

### DIFF
--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -44,7 +44,7 @@ class CompletionWidget(QtGui.QListWidget):
         self.itemActivated.connect(self._complete_current)
 
     def eventFilter(self, obj, event):
-        """ Reimplemented to handle keyboard input and to auto-hide when the
+        """ Reimplemented to handle mouse input and to auto-hide when the
             text edit loses focus.
         """
         if obj is self:
@@ -87,7 +87,6 @@ class CompletionWidget(QtGui.QListWidget):
         """
         super(CompletionWidget, self).hideEvent(event)
         self._text_edit.cursorPositionChanged.disconnect(self._update_current)
-        self._text_edit.removeEventFilter(self)
         self.removeEventFilter(self)
 
     def showEvent(self, event):
@@ -95,7 +94,6 @@ class CompletionWidget(QtGui.QListWidget):
         """
         super(CompletionWidget, self).showEvent(event)
         self._text_edit.cursorPositionChanged.connect(self._update_current)
-        self._text_edit.installEventFilter(self)
         self.installEventFilter(self)
 
     #--------------------------------------------------------------------------

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -136,6 +136,7 @@ class CompletionWidget(QtGui.QListWidget):
         self.setGeometry(point.x(), point.y(), w, height)
         self._start_position = cursor.position()
         self.setCurrentRow(0)
+        self.raise_()
         self.show()
 
     #--------------------------------------------------------------------------

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -95,17 +95,18 @@ class CompletionWidget(QtGui.QListWidget):
         text_edit = self._text_edit
         point = text_edit.cursorRect(cursor).bottomRight()
         point = text_edit.mapToGlobal(point)
-        height = self.sizeHint().height()
-        screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
-        if (screen_rect.size().height() + screen_rect.y() 
-                    - point.y() - height < 0):
-            point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
-            point.setY(point.y() - height)
-        self.move(point)
-
-        self._start_position = cursor.position()
         self.clear()
         self.addItems(items)
+        height = self.sizeHint().height()
+        screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
+        if (screen_rect.size().height() + screen_rect.y() -
+                point.y() - height < 0):
+            point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
+            point.setY(point.y() - height)
+        w = (self.sizeHintForColumn(0) +
+             self.verticalScrollBar().sizeHint().width())
+        self.setGeometry(point.x(), point.y(), w, height)
+        self._start_position = cursor.position()
         self.setCurrentRow(0)
         self.show()
 

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -68,8 +68,7 @@ class CompletionWidget(QtGui.QListWidget):
                 pos = self.mapToGlobal(event.pos())
                 target = QtGui.QApplication.widgetAt(pos)
                 if (target and self.isAncestorOf(target) or target is self):
-                    target.event(event)
-                    return True
+                    return False
                 else:
                     self.cancel_completion()
                     if target:

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -40,7 +40,7 @@ class CompletionWidget(QtGui.QListWidget):
             etype = event.type()
 
             if etype == QtCore.QEvent.KeyPress:
-                key, text = event.key(), event.text()
+                key = event.key()
                 if key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter,
                            QtCore.Qt.Key_Tab):
                     self._complete_current()

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -39,10 +39,10 @@ class CompletionWidget(QtGui.QListWidget):
             flags = QtCore.Qt.ToolTip | QtCore.Qt.WindowStaysOnTopHint
 
         self.setAttribute(QtCore.Qt.WA_StaticContents)
-        origPolicy = text_edit.focusPolicy()
+        original_policy = text_edit.focusPolicy()
         self.setWindowFlags(flags)
         self.setFocusPolicy(QtCore.Qt.NoFocus)
-        text_edit.setFocusPolicy(origPolicy)
+        text_edit.setFocusPolicy(original_policy)
 
         # Ensure that the text edit keeps focus when widget is displayed.
         self.setFocusProxy(self._text_edit)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -66,6 +66,15 @@ class CompletionWidget(QtGui.QListWidget):
 
         return super(CompletionWidget, self).eventFilter(obj, event)
 
+    def keyPressEvent(self, event):
+        key = event.key()
+        if key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
+                   QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown,
+                   QtCore.Qt.Key_Home, QtCore.Qt.Key_End):
+            return super(CompletionWidget, self).keyPressEvent(event)
+        else:
+            QtGui.QApplication.sendEvent(self._text_edit, event)
+
     #--------------------------------------------------------------------------
     # 'QWidget' interface
     #--------------------------------------------------------------------------

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -20,9 +20,16 @@ class CompletionWidget(QtGui.QListWidget):
         super(CompletionWidget, self).__init__()
 
         self._text_edit = text_edit
+        self.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
+        self.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
 
         self.setAttribute(QtCore.Qt.WA_StaticContents)
-        self.setWindowFlags(QtCore.Qt.ToolTip | QtCore.Qt.WindowStaysOnTopHint)
+        origPolicy = text_edit.focusPolicy()
+        self.setWindowFlags(QtCore.Qt.Popup)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        text_edit.setFocusPolicy(origPolicy)
 
         # Ensure that the text edit keeps focus when widget is displayed.
         self.setFocusProxy(self._text_edit)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -63,6 +63,18 @@ class CompletionWidget(QtGui.QListWidget):
 
             elif etype == QtCore.QEvent.FocusOut:
                 self.hide()
+        elif obj is self:
+            if event.type() == QtCore.QEvent.MouseButtonPress:
+                pos = self.mapToGlobal(event.pos())
+                target = QtGui.QApplication.widgetAt(pos)
+                if (target and self.isAncestorOf(target) or target is self):
+                    target.event(event)
+                    return True
+                else:
+                    self.cancel_completion()
+                    if target:
+                        target.event(event)
+                    return True
 
         return super(CompletionWidget, self).eventFilter(obj, event)
 
@@ -85,6 +97,7 @@ class CompletionWidget(QtGui.QListWidget):
         super(CompletionWidget, self).hideEvent(event)
         self._text_edit.cursorPositionChanged.disconnect(self._update_current)
         self._text_edit.removeEventFilter(self)
+        self.removeEventFilter(self)
 
     def showEvent(self, event):
         """ Reimplemented to connect signal handlers and event filter.
@@ -92,6 +105,7 @@ class CompletionWidget(QtGui.QListWidget):
         super(CompletionWidget, self).showEvent(event)
         self._text_edit.cursorPositionChanged.connect(self._update_current)
         self._text_edit.installEventFilter(self)
+        self.installEventFilter(self)
 
     #--------------------------------------------------------------------------
     # 'CompletionWidget' interface

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -55,12 +55,6 @@ class CompletionWidget(QtGui.QListWidget):
                     return False
                 else:
                     self.cancel_completion()
-                    if target:
-                        try:
-                            target.event(event)
-                        except RuntimeError:
-                            pass
-                    return True
 
         return super(CompletionWidget, self).eventFilter(obj, event)
 

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -26,9 +26,16 @@ class CompletionWidget(QtGui.QListWidget):
         self.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
         self.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
 
+        # Use platform specific window flags to ensure correct behavior
+        # See github.com/jupyter/qtconsole/pull/93 for detailed discussion
         if os.name == 'nt':
+            # On windows, we need Popup style to ensure correct mouse
+            # interaction (dialog would dissappear on mouse click with
+            # ToolTip style)
             flags = QtCore.Qt.Popup
         else:
+            # On other OS, we need ToolTip style to ensure that the widget
+            # shows correctly (dialog is not drawn with Popup style)
             flags = QtCore.Qt.ToolTip | QtCore.Qt.WindowStaysOnTopHint
 
         self.setAttribute(QtCore.Qt.WA_StaticContents)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -1,5 +1,6 @@
 """A dropdown completer widget for the qtconsole."""
 # System library imports
+import os
 from qtconsole.qt import QtCore, QtGui
 
 
@@ -25,9 +26,14 @@ class CompletionWidget(QtGui.QListWidget):
         self.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
         self.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
 
+        if os.name == 'nt':
+            flags = QtCore.Qt.Popup
+        else:
+            flags = QtCore.Qt.ToolTip | QtCore.Qt.WindowStaysOnTopHint
+
         self.setAttribute(QtCore.Qt.WA_StaticContents)
         origPolicy = text_edit.focusPolicy()
-        self.setWindowFlags(QtCore.Qt.Popup)
+        self.setWindowFlags(flags)
         self.setFocusPolicy(QtCore.Qt.NoFocus)
         text_edit.setFocusPolicy(origPolicy)
 

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -36,7 +36,7 @@ class CompletionWidget(QtGui.QListWidget):
         """ Reimplemented to handle keyboard input and to auto-hide when the
             text edit loses focus.
         """
-        if obj == self._text_edit:
+        if obj is self._text_edit:
             etype = event.type()
 
             if etype == QtCore.QEvent.KeyPress:

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -18,6 +18,8 @@ elif api == QT_API_PYQT5:
 elif api == QT_API_PYSIDE:
     from PySide.QtTest import QTest
 
+setup = dec.skip_file_no_x11(__name__)
+
 
 class TestCompletionWidget(unittest.TestCase):
 

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -3,9 +3,20 @@ import unittest
 
 from qtconsole.qt import QtCore, QtGui
 
+from qtconsole.qt_loaders import (loaded_api, QT_API_PYQT, QT_API_PYQT5,
+QT_API_PYQTv1, QT_API_PYQT_DEFAULT, QT_API_PYSIDE)
+
 from qtconsole.console_widget import ConsoleWidget
 from qtconsole.completion_widget import CompletionWidget
 import ipython_genutils.testing.decorators as dec
+
+api = loaded_api()
+if api in (QT_API_PYQT, QT_API_PYQTv1, QT_API_PYQT_DEFAULT):
+    from PyQt4.QtTest import QTest
+elif api == QT_API_PYQT5:
+    from PyQt5.QtTest import QTest
+elif api == QT_API_PYSIDE:
+    from PySide.QtTest import QTest
 
 setup = dec.skip_file_no_x11(__name__)
 
@@ -39,13 +50,8 @@ class TestCompletionWidget(unittest.TestCase):
         self.assertTrue(w.isVisible())
 
     def test_html_completer_keyboard(self):
-        noModifiers = QtCore.Qt.KeyboardModifiers(0)
         w = CompletionWidget(self.console)
         w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
-        downEvent = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
-                                    QtCore.Qt.Key_PageDown, noModifiers)
-        self._app.sendEvent(self.text_edit, downEvent)
-        enterEvent = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
-                                     QtCore.Qt.Key_Enter, noModifiers)
-        self._app.sendEvent(self.text_edit, enterEvent)
+        QTest.keyClick(self.text_edit, QtCore.Qt.Key_PageDown)
+        QTest.keyClick(self.text_edit, QtCore.Qt.Key_Enter)
         self.assertEqual(self.text_edit.toPlainText(), "item3")

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from qtconsole.qt import QtCore, QtGui
+
+from qtconsole.console_widget import ConsoleWidget
+from qtconsole.completion_widget import CompletionWidget
+import ipython_genutils.testing.decorators as dec
+
+setup = dec.skip_file_no_x11(__name__)
+
+
+class TestCompletionWidget(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """ Create the application for the test case.
+        """
+        cls._app = QtGui.QApplication.instance()
+        if cls._app is None:
+            cls._app = QtGui.QApplication([])
+        cls._app.setQuitOnLastWindowClosed(False)
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Exit the application.
+        """
+        QtGui.QApplication.quit()
+
+    def setUp(self):
+        """ Create the main widgets (ConsoleWidget)
+        """
+        self.console = ConsoleWidget()
+        self.text_edit = self.console._control
+
+    def test_html_completer_shows(self):
+        w = CompletionWidget(self.console)
+        w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
+        self.assertTrue(w.isVisible())
+
+    def test_html_completer_keyboard(self):
+        noModifiers = QtCore.Qt.KeyboardModifiers(0)
+        w = CompletionWidget(self.console)
+        w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
+        downEvent = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                    QtCore.Qt.Key_PageDown, noModifiers)
+        self._app.sendEvent(self.text_edit, downEvent)
+        enterEvent = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                     QtCore.Qt.Key_Enter, noModifiers)
+        self._app.sendEvent(self.text_edit, enterEvent)
+        self.assertEqual(self.text_edit.toPlainText(), "item3")

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -3,20 +3,20 @@ import unittest
 
 from qtconsole.qt import QtCore, QtGui
 
-from qtconsole.qt_loaders import (loaded_api, QT_API_PYQT, QT_API_PYQT5,
-QT_API_PYQTv1, QT_API_PYQT_DEFAULT, QT_API_PYSIDE)
+from qtconsole.qt_loaders import loaded_api, QT_API_PYQT5, QT_API_PYSIDE
 
 from qtconsole.console_widget import ConsoleWidget
 from qtconsole.completion_widget import CompletionWidget
 import ipython_genutils.testing.decorators as dec
 
+
 api = loaded_api()
-if api in (QT_API_PYQT, QT_API_PYQTv1, QT_API_PYQT_DEFAULT):
-    from PyQt4.QtTest import QTest
-elif api == QT_API_PYQT5:
+if api == QT_API_PYQT5:
     from PyQt5.QtTest import QTest
 elif api == QT_API_PYSIDE:
     from PySide.QtTest import QTest
+else:
+    from PyQt4.QtTest import QTest
 
 setup = dec.skip_file_no_x11(__name__)
 

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -55,3 +55,16 @@ class TestCompletionWidget(unittest.TestCase):
         QTest.keyClick(self.text_edit, QtCore.Qt.Key_PageDown)
         QTest.keyClick(self.text_edit, QtCore.Qt.Key_Enter)
         self.assertEqual(self.text_edit.toPlainText(), "item3")
+
+    def test_html_completer_mousepick(self):
+        leftButton = QtCore.Qt.LeftButton
+
+        w = CompletionWidget(self.console)
+        w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
+
+        QTest.mouseClick(w.viewport(), leftButton, pos=QtCore.QPoint(19, 8))
+        QTest.mouseRelease(w.viewport(), leftButton, pos=QtCore.QPoint(19, 8))
+        QTest.mouseDClick(w.viewport(), leftButton, pos=QtCore.QPoint(19, 8))
+
+        self.assertEqual(self.text_edit.toPlainText(), "item1")
+        self.assertFalse(w.isVisible())

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -44,19 +44,19 @@ class TestCompletionWidget(unittest.TestCase):
         self.console = ConsoleWidget()
         self.text_edit = self.console._control
 
-    def test_html_completer_shows(self):
+    def test_droplist_completer_shows(self):
         w = CompletionWidget(self.console)
         w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
         self.assertTrue(w.isVisible())
 
-    def test_html_completer_keyboard(self):
+    def test_droplist_completer_keyboard(self):
         w = CompletionWidget(self.console)
         w.show_items(self.text_edit.textCursor(), ["item1", "item2", "item3"])
-        QTest.keyClick(self.text_edit, QtCore.Qt.Key_PageDown)
-        QTest.keyClick(self.text_edit, QtCore.Qt.Key_Enter)
+        QTest.keyClick(w, QtCore.Qt.Key_PageDown)
+        QTest.keyClick(w, QtCore.Qt.Key_Enter)
         self.assertEqual(self.text_edit.toPlainText(), "item3")
 
-    def test_html_completer_mousepick(self):
+    def test_droplist_completer_mousepick(self):
         leftButton = QtCore.Qt.LeftButton
 
         w = CompletionWidget(self.console)

--- a/qtconsole/tests/test_completion_widget.py
+++ b/qtconsole/tests/test_completion_widget.py
@@ -18,8 +18,6 @@ elif api == QT_API_PYQT5:
 elif api == QT_API_PYSIDE:
     from PySide.QtTest import QTest
 
-setup = dec.skip_file_no_x11(__name__)
-
 
 class TestCompletionWidget(unittest.TestCase):
 


### PR DESCRIPTION
Currently, if you click on the `CompletionWidget` with the mouse, it gets focus (Windows 10, 64-bit, PyQt4). This triggers the `CompletionWidget` to hide. To prevent this, check the active window before hiding. Next, since it now has focus, any keyboard input to the `CompletionWidget` needs to be redirected to its `_text_editor`, except the input that is intended for it (up/down/page up/page down/home/end).