### PR TITLE
Fix Latex support

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -138,11 +138,11 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                try:
-                    self._append_latex(data['text/latex'], True)
-                except Exception:
-                    self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
-                    return super(RichJupyterWidget, self)._handle_execute_result(msg)
+                png = latex_to_png(data['text/latex'], wrap=False)
+                if png:
+                    self._append_png(png, True)
+                else:
+                    return super(RichJupyterWidget, self)._handle_display_data(msg)
                 self._append_html(self.output_sep2, True)
             else:
                 # Default back to the plain text representation.
@@ -170,10 +170,10 @@ class RichJupyterWidget(RichIPythonWidget):
                 jpg = decodestring(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
             elif 'text/latex' in data and latex_to_png:
-                try:
-                    self._append_latex(data['text/latex'], True)
-                except Exception:
-                    self.log.error("Failed to render latex: '%s'", data['text/latex'], exc_info=True)
+                png = latex_to_png(data['text/latex'], wrap=False)
+                if png:
+                    self._append_png(png, True)
+                else:
                     return super(RichJupyterWidget, self)._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.
@@ -182,10 +182,6 @@ class RichJupyterWidget(RichIPythonWidget):
     #---------------------------------------------------------------------------
     # 'RichJupyterWidget' protected interface
     #---------------------------------------------------------------------------
-
-    def _append_latex(self, latex, before_prompt=False, metadata=None):
-        """ Append latex data to the widget."""
-        self._append_png(latex_to_png(latex, wrap=False), before_prompt, metadata)
 
     def _append_jpg(self, jpg, before_prompt=False, metadata=None):
         """ Append raw JPG data to the widget."""

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -183,9 +183,13 @@ class RichJupyterWidget(RichIPythonWidget):
 
     def _append_latex(self, latex, before_prompt=False, metadata=None):
         """ Append latex data to the widget."""
-        png = latex_to_png(latex, wrap=False)
-        if png:
-            self._append_png(png, before_prompt, metadata)
+        supported_latex = latex.startswith('$') and latex.endswith('$')
+        if supported_latex:
+            png = latex_to_png(latex, wrap=False)
+            if png:
+                self._append_png(png, before_prompt, metadata)
+            else:
+                raise ValueError
         else:
             raise ValueError
 

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -180,10 +180,36 @@ class RichJupyterWidget(RichIPythonWidget):
     #---------------------------------------------------------------------------
     # 'RichJupyterWidget' protected interface
     #---------------------------------------------------------------------------
+    def _is_latex_math(self, latex):
+        """
+        Determine if a Latex string is in math mode
+
+        This is the only mode supported by qtconsole
+        """
+        basic_envs = ['math', 'displaymath']
+        starable_envs = ['equation', 'eqnarray' 'multline', 'gather', 'align',
+                         'flalign', 'alignat']
+        star_envs = [env + '*' for env in starable_envs]
+        envs = basic_envs + starable_envs + star_envs
+
+        env_syntax = [r'\begin{{{0}}} \end{{{0}}}'.format(env).split() for env in envs]
+
+        math_syntax = [
+            (r'\[', r'\]'), (r'\(', r'\)'),
+            ('$$', '$$'), ('$', '$'),
+        ]
+
+        for start, end in math_syntax + env_syntax:
+            inner = latex[len(start):-len(end)]
+            if start in inner or end in inner:
+                return False
+            if latex.startswith(start) and latex.endswith(end):
+                return True
+        return False
 
     def _append_latex(self, latex, before_prompt=False, metadata=None):
         """ Append latex data to the widget."""
-        supported_latex = latex.startswith('$') and latex.endswith('$')
+        supported_latex = self._is_latex_math(latex)
         if supported_latex:
             png = latex_to_png(latex, wrap=False)
             if png:

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -209,13 +209,15 @@ class RichJupyterWidget(RichIPythonWidget):
 
     def _append_latex(self, latex, before_prompt=False, metadata=None):
         """ Append latex data to the widget."""
-        supported_latex = self._is_latex_math(latex)
-        if supported_latex:
-            png = latex_to_png(latex, wrap=False)
-            if png:
-                self._append_png(png, before_prompt, metadata)
-            else:
-                raise ValueError
+        png = None
+        if self._is_latex_math(latex):
+            png = latex_to_png(latex, wrap=False, backend='dvipng')
+        if png is None and latex.startswith('$') and latex.endswith('$'):
+            # matplotlib only supports strings enclosed in dollar signs
+            png = latex_to_png(latex, wrap=False, backend='matplotlib')
+
+        if png:
+            self._append_png(png, before_prompt, metadata)
         else:
             raise ValueError
 

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -138,7 +138,10 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                self._append_latex(data['text/latex'], True)
+                try:
+                    self._append_latex(data['text/latex'], True)
+                except ValueError:
+                    return super(RichJupyterWidget, self)._handle_display_data(msg)
                 self._append_html(self.output_sep2, True)
             else:
                 # Default back to the plain text representation.
@@ -166,7 +169,10 @@ class RichJupyterWidget(RichIPythonWidget):
                 jpg = decodestring(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
             elif 'text/latex' in data and latex_to_png:
-                self._append_latex(data['text/latex'], True)
+                try:
+                    self._append_latex(data['text/latex'], True)
+                except ValueError:
+                    return super(RichJupyterWidget, self)._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.
                 return super(RichJupyterWidget, self)._handle_display_data(msg)
@@ -181,7 +187,7 @@ class RichJupyterWidget(RichIPythonWidget):
         if png:
             self._append_png(png, before_prompt, metadata)
         else:
-            return super(RichJupyterWidget, self)._handle_display_data(msg)
+            raise ValueError
 
     def _append_jpg(self, jpg, before_prompt=False, metadata=None):
         """ Append raw JPG data to the widget."""

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -20,6 +20,10 @@ except ImportError:
     latex_to_png = None
 
 
+class LatexError(Exception):
+    """Exception for Latex errors"""
+
+
 class RichIPythonWidget(JupyterWidget):
     """Dummy class for config inheritance. Destroyed below."""
 
@@ -140,7 +144,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._pre_image_append(msg, prompt_number)
                 try:
                     self._append_latex(data['text/latex'], True)
-                except ValueError:
+                except LatexError:
                     return super(RichJupyterWidget, self)._handle_display_data(msg)
                 self._append_html(self.output_sep2, True)
             else:
@@ -171,7 +175,7 @@ class RichJupyterWidget(RichIPythonWidget):
             elif 'text/latex' in data and latex_to_png:
                 try:
                     self._append_latex(data['text/latex'], True)
-                except ValueError:
+                except LatexError:
                     return super(RichJupyterWidget, self)._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.
@@ -219,7 +223,7 @@ class RichJupyterWidget(RichIPythonWidget):
         if png:
             self._append_png(png, before_prompt, metadata)
         else:
-            raise ValueError
+            raise LatexError
 
     def _append_jpg(self, jpg, before_prompt=False, metadata=None):
         """ Append raw JPG data to the widget."""

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -138,11 +138,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                png = latex_to_png(data['text/latex'], wrap=False)
-                if png:
-                    self._append_png(png, True)
-                else:
-                    return super(RichJupyterWidget, self)._handle_display_data(msg)
+                self._append_latex(data['text/latex'], True)
                 self._append_html(self.output_sep2, True)
             else:
                 # Default back to the plain text representation.
@@ -170,11 +166,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 jpg = decodestring(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
             elif 'text/latex' in data and latex_to_png:
-                png = latex_to_png(data['text/latex'], wrap=False)
-                if png:
-                    self._append_png(png, True)
-                else:
-                    return super(RichJupyterWidget, self)._handle_display_data(msg)
+                self._append_latex(data['text/latex'], True)
             else:
                 # Default back to the plain text representation.
                 return super(RichJupyterWidget, self)._handle_display_data(msg)
@@ -182,6 +174,14 @@ class RichJupyterWidget(RichIPythonWidget):
     #---------------------------------------------------------------------------
     # 'RichJupyterWidget' protected interface
     #---------------------------------------------------------------------------
+
+    def _append_latex(self, latex, before_prompt=False, metadata=None):
+        """ Append latex data to the widget."""
+        png = latex_to_png(latex, wrap=False)
+        if png:
+            self._append_png(png, before_prompt, metadata)
+        else:
+            return super(RichJupyterWidget, self)._handle_display_data(msg)
 
     def _append_jpg(self, jpg, before_prompt=False, metadata=None):
         """ Append raw JPG data to the widget."""


### PR DESCRIPTION
Fixes #56 

This builds on top of ipython/ipython#9203, so that one has to be merged first.

Pinging @flying-sheep, @asmeurer and @jorisvandenbossche

----

Tasks:

- [x] Fix the case when neither Matplotlib nor Latex are installed. Qtconsole was displaying an empty image when it should move to use the plain text repr.
- [x] Fix the case when Matplotlib is incapable of handling Latex. Qtconsole was printing a huge traceback, even after pull request #65 .
- [x] Fix the case when Latex doesn't come in math mode. This will fix the issues with IRKernel and Pandas.
- [x] Bonus: First try to use **Latex**, then **Matplotlib** to generate the representation.