### PR TITLE
Home key event updated.

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1371,10 +1371,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
                     start_pos = cursor.position()
                     start_pos += len(self._continuation_prompt)
                     cursor.setPosition(position)
+
                 c = self._get_cursor()
                 spaces = self._get_leading_spaces()
-                if c.position() > start_pos + spaces:
-                    start_pos += spaces
+                if (c.position() > start_pos + spaces or
+                        c.columnNumber() == len(self._continuation_prompt)):
+                    start_pos += spaces     # Beginning of text
+
                 if shift_down and self._in_buffer(position):
                     if c.selectedText():
                         sel_max = max(c.selectionStart(), c.selectionEnd())

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1371,7 +1371,15 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
                     start_pos = cursor.position()
                     start_pos += len(self._continuation_prompt)
                     cursor.setPosition(position)
+                c = self._get_cursor()
+                spaces = self._get_leading_spaces()
+                if c.position() > start_pos + spaces:
+                    start_pos += spaces
                 if shift_down and self._in_buffer(position):
+                    if c.selectedText():
+                        sel_max = max(c.selectionStart(), c.selectionEnd())
+                        cursor.setPosition(sel_max,
+                                           QtGui.QTextCursor.MoveAnchor)
                     cursor.setPosition(start_pos, QtGui.QTextCursor.KeepAnchor)
                 else:
                     cursor.setPosition(start_pos)


### PR DESCRIPTION
Move cursor to beginning of text instead of beginning of line
in the case line starts with leading spaces. This is the same
behaviour used by common text editors/IDEs like SublimeText
and PyCharm.