### PR TITLE
Enter, Return key event modified

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1166,12 +1166,15 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
                         self.execute(interactive = not shift_down)
                     else:
                         # Do this inside an edit block for clean undo/redo.
-                        indent = self._get_next_row_indent()
+                        pos = self._get_input_buffer_cursor_pos()
+                        complete, indent = self._is_complete(
+                            self._get_input_buffer()[:pos], True)
                         cursor.beginEditBlock()
                         cursor.setPosition(position)
                         cursor.insertText('\n')
                         self._insert_continuation_prompt(cursor)
-                        cursor.insertText(' ' * indent)
+                        if indent:
+                            cursor.insertText(indent)
                         cursor.endEditBlock()
 
                         # Ensure that the whole input buffer is visible.
@@ -1661,22 +1664,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
         cur.select(QtGui.QTextCursor.LineUnderCursor)
         text = cur.selectedText()[len(self._continuation_prompt):]
         return len(text) - len(text.lstrip())
-
-    def _get_next_row_indent(self):
-        """ Convenience method that returns the number of leading spaces
-        to be used as indentation in the following line.
-        """
-        cur = self._control.textCursor()
-        prompt = len(self._continuation_prompt)
-        cur_pos = cur.columnNumber() - prompt
-        cur.select(QtGui.QTextCursor.LineUnderCursor)
-        text = cur.selectedText()[prompt:]
-        leading_spaces = len(text) - len(text.lstrip())
-        if cur_pos < leading_spaces:
-            indent = cur_pos
-        else:
-            indent = leading_spaces
-        return indent
 
     def _get_prompt_cursor(self):
         """ Convenience method that returns a cursor for the prompt position.

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1676,8 +1676,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
             indent = cur_pos
         else:
             indent = leading_spaces
-            if 0 < len(text) <= cur_pos and text.rstrip()[-1] == ':':
-                indent += 4
         return indent
 
     def _get_prompt_cursor(self):


### PR DESCRIPTION
The Enter/Return key event is updated to also indent new lines
within an existing text block. Currently only lines added at the
bottom of the console are indented.