### PR TITLE
Make SuperQObject logic reusable with other Qt bases

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -208,6 +208,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             The parent for this widget.
         """
         super(ConsoleWidget, self).__init__(**kw)
+        if parent:
+            self.setParent(parent)
 
         # While scrolling the pager on Mac OS X, it tears badly.  The
         # NativeGesture is platform and perhaps build-specific hence

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -15,7 +15,7 @@ from qtconsole.qt import QtCore, QtGui
 
 from traitlets.config.configurable import LoggingConfigurable
 from qtconsole.rich_text import HtmlExporter
-from qtconsole.util import MetaQObjectHasTraits, get_font
+from qtconsole.util import MetaQObjectHasTraits, get_font, superQ
 from ipython_genutils.text import columnize
 from traitlets import Bool, Enum, Integer, Unicode
 from .ansi_code_processor import QtAnsiCodeProcessor
@@ -35,7 +35,7 @@ def is_letter_or_number(char):
 # Classes
 #-----------------------------------------------------------------------------
 
-class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.QWidget), {})):
+class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ(QtGui.QWidget)), {})):
     """ An abstract base class for console-type widgets. This class has
         functionality for:
 
@@ -207,8 +207,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
         parent : QWidget, optional [default None]
             The parent for this widget.
         """
-        QtGui.QWidget.__init__(self, parent)
-        LoggingConfigurable.__init__(self, **kw)
+        super(ConsoleWidget, self).__init__(**kw)
 
         # While scrolling the pager on Mac OS X, it tears badly.  The
         # NativeGesture is platform and perhaps build-specific hence

--- a/qtconsole/util.py
+++ b/qtconsole/util.py
@@ -45,8 +45,8 @@ class MetaQObjectHasTraits(MetaQObject, MetaHasTraits):
 # Classes
 #-----------------------------------------------------------------------------
 
-class SuperQObject(QtCore.QObject):
-    """ Permits the use of super() in class hierarchies that contain QObject.
+def superQ(QClass):
+    """ Permits the use of super() in class hierarchies that contain Qt classes.
 
     Unlike QObject, SuperQObject does not accept a QObject parent. If it did,
     super could not be emulated properly (all other classes in the heierarchy
@@ -56,22 +56,27 @@ class SuperQObject(QtCore.QObject):
     This class is primarily useful for attaching signals to existing non-Qt
     classes. See QtKernelManagerMixin for an example.
     """
+    class SuperQClass(QClass):
 
-    def __new__(cls, *args, **kw):
-        # We initialize QObject as early as possible. Without this, Qt complains
-        # if SuperQObject is not the first class in the super class list.
-        inst = QtCore.QObject.__new__(cls)
-        QtCore.QObject.__init__(inst)
-        return inst
+        def __new__(cls, *args, **kw):
+            # We initialize QClass as early as possible. Without this, Qt complains
+            # if SuperQClass is not the first class in the super class list.
+            inst = QClass.__new__(cls)
+            QClass.__init__(inst)
+            return inst
 
-    def __init__(self, *args, **kw):
-        # Emulate super by calling the next method in the MRO, if there is one.
-        mro = self.__class__.mro()
-        for qt_class in QtCore.QObject.mro():
-            mro.remove(qt_class)
-        next_index = mro.index(SuperQObject) + 1
-        if next_index < len(mro):
-            mro[next_index].__init__(self, *args, **kw)
+        def __init__(self, *args, **kw):
+            # Emulate super by calling the next method in the MRO, if there is one.
+            mro = self.__class__.mro()
+            for qt_class in QClass.mro():
+                mro.remove(qt_class)
+            next_index = mro.index(SuperQClass) + 1
+            if next_index < len(mro):
+                mro[next_index].__init__(self, *args, **kw)
+
+    return SuperQClass
+
+SuperQObject = superQ(QtCore.QObject)
 
 #-----------------------------------------------------------------------------
 # Functions


### PR DESCRIPTION
And apply it to QWidget in ConsoleWidget.

Fixes double-initialization in ConsoleWidget with:

- PySide
- traitlets 4.2, which calls super in `__init__` now

closes #104