### PR TITLE
request kernel_info on start_channels

### DIFF
--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -281,6 +281,7 @@ class JupyterWidget(IPythonWidget):
     def _started_channels(self):
         """Make a history request"""
         self._starting = True
+        self.kernel_client.kernel_info()
         self.kernel_client.history(hist_access_type='tail', n=1000)
 
 


### PR DESCRIPTION
fixes regression where prompt would never be shown for `--existing`
consoles.

closes #115