### PR TITLE
BUG: Rename width/height traits to avoid QWidget override.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,17 @@
 Changes in Jupyter Qt console
 =============================
 
+.. _4.3:
+
+4.3
+---
+
+`4.3 on GitHub <https://github.com/jupyter/qtconsole/milestones/4.3>`__
+
+- Rename `ConsoleWidget.width/height` traits to `console_width/console_height`
+  to avoid a name clash with the `QWidget` properties.
+  WARNING: possibly, but unlikely code-breaking.
+
 .. _4.2:
 
 4.2

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -132,12 +132,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         with the size of the font.
         """)
 
-    width = Integer(81, config=True,
+    console_width = Integer(81, config=True,
         help="""The width of the console at start time in number
         of characters (will double with `hsplit` paging)
         """)
 
-    height = Integer(25, config=True,
+    console_height = Integer(25, config=True,
         help="""The height of the console at start time in number
         of characters (will double with `vsplit` paging)
         """)
@@ -472,12 +472,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # a fudge factor of one character here.
         # Note 2: QFontMetrics.maxWidth is not used here or anywhere else due
         # to a Qt bug on certain Mac OS systems where it returns 0.
-        width = font_metrics.width(' ') * self.width + margin
+        width = font_metrics.width(' ') * self.console_width + margin
         width += style.pixelMetric(QtGui.QStyle.PM_ScrollBarExtent)
         if self.paging == 'hsplit':
             width = width * 2 + splitwidth
 
-        height = font_metrics.height() * self.height + margin
+        height = font_metrics.height() * self.console_height + margin
         if self.paging == 'vsplit':
             height = height * 2 + splitwidth
 

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -76,4 +76,9 @@ class TestConsoleWidget(unittest.TestCase):
         w.eventFilter(obj, stillOverTextEvent)
         self.assertEqual(tip.isVisible(), True)
         self.assertEqual(tip.text(), "http://python.org")
-        
+
+    def test_width_height(self):
+        # width()/height() QWidget properties should not be overridden.
+        w = ConsoleWidget()
+        self.assertEqual(w.width(), QtGui.QWidget.width(w))
+        self.assertEqual(w.height(), QtGui.QWidget.height(w))


### PR DESCRIPTION
Fixes #124

Not sure what should be done with the changelog to document this.