### PR TITLE
Add --help-all doc

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -19,6 +19,9 @@ These options can be set in the configuration file,
 ``~/.jupyter/jupyter_qtconsole_config.py``, or
 at the command line when you start Qt console.
 
+You may enter ``jupyter qtconsole --help-all`` to get information
+about all available configuration options.
+
 Options
 -------
 """


### PR DESCRIPTION
Based on feedback in another repo https://github.com/jupyter/help/issues/13#issuecomment-206039381, this PR adds documentation about ``jupyter qtconsole --help-all``.