### PR TITLE
qt_loaders: bugfix for imp.find_module failure on Python 3.5 Windows 7

### DIFF
--- a/qtconsole/qt_loaders.py
+++ b/qtconsole/qt_loaders.py
@@ -123,12 +123,12 @@ def has_binding(api):
         #importing top level PyQt4/PySide module is ok...
         mod = __import__(module_name)
         #...importing submodules is not
-        imp.find_module('QtCore', mod.__path__)
-        imp.find_module('QtGui', mod.__path__)
-        imp.find_module('QtSvg', mod.__path__)
+        imp.find_module('QtCore', list(mod.__path__))
+        imp.find_module('QtGui', list(mod.__path__))
+        imp.find_module('QtSvg', list(mod.__path__))
         if api == QT_API_PYQT5:
             # QT5 requires QtWidgets too
-            imp.find_module('QtWidgets', mod.__path__)
+            imp.find_module('QtWidgets', list(mod.__path__))
 
         #we can also safely check PySide version
         if api == QT_API_PYSIDE:


### PR DESCRIPTION
**Exception:**
```
> python.exe -m qtconsole

Traceback (most recent call last):
  File "C:\Python\3.5\Win64\lib\runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python\3.5\Win64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\__main__.py", line 2, in
 <module>
    from qtconsole.qtconsoleapp import main
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\qtconsoleapp.py", line 6
0, in <module>
    from qtconsole.qt import QtCore, QtGui
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\qt.py", line 23, in <mod
ule>
    QtCore, QtGui, QtSvg, QT_API = load_qt(api_opts)
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\qt_loaders.py", line 314
, in load_qt
    if not can_import(api):
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\qt_loaders.py", line 172
, in can_import
    if not has_binding(api):
  File "C:\Python\3.5\Win64\lib\site-packages\qtconsole\qt_loaders.py", line 137
, in has_binding
    imp.find_module('QtCore', mod.__path__)
  File "C:\Python\3.5\Win64\lib\imp.py", line 270, in find_module
    "not {}".format(type(name)))
RuntimeError: 'list' must be None or a list, not <class 'str'>
```
**Docs:**
[PEP420](https://www.python.org/dev/peps/pep-0420/) says that `__path__ attribute is a read-only iterable of strings` and in my case on Windows 7 for Python 3.5.2 `__path__` is not a list, but is a _NamespacePath instance

And [imp.find_module(name[, path])](https://docs.python.org/3.5/library/imp.html#imp.find_module) expects path to be None or `must be a list of directory names` and it checks it explicitly

