### PR TITLE
[MRG] Fix error messages when using %run

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -484,8 +484,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                 self._process_execute_ok(msg)
             elif status == 'aborted':
                 self._process_execute_abort(msg)
-            # If status == 'error', a message of type 'error' will be sent with
-            # the details
 
             self._show_interpreter_prompt_for_reply(msg)
             self.executed.emit(msg)

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -482,7 +482,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             status = content['status']
             if status == 'ok':
                 self._process_execute_ok(msg)
-            # Of status != 'ok', a message of type 'error' will be sent with
+            elif status == 'aborted':
+                self._process_execute_abort(msg)
+            # If status == 'error', a message of type 'error' will be sent with
             # the details
 
             self._show_interpreter_prompt_for_reply(msg)

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -482,10 +482,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             status = content['status']
             if status == 'ok':
                 self._process_execute_ok(msg)
-            elif status == 'error':
-                self._process_execute_error(msg)
-            elif status == 'aborted':
-                self._process_execute_abort(msg)
+            # Of status != 'ok', a message of type 'error' will be sent with
+            # the details
 
             self._show_interpreter_prompt_for_reply(msg)
             self.executed.emit(msg)
@@ -495,6 +493,11 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self._request_info['execute'].pop(msg_id)
         elif info and not self._hidden:
             raise RuntimeError("Unknown handler for %s" % info.kind)
+
+    def _handle_error(self, msg):
+        """ Handle error messages.
+        """
+        self._process_execute_error(msg)
 
     def _handle_input_request(self, msg):
         """ Handle requests for raw_input.

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -293,29 +293,24 @@ class JupyterWidget(IPythonWidget):
         """Handle an execute_error message"""
         content = msg['content']
 
-        if content['ename'] == 'KeyboardInterrupt':
-            # If the user interrupted execution by pressing CTRL-C, only
-            # display a simple message.
-            self._append_plain_text("Execution aborted\n")
+        traceback = '\n'.join(content['traceback']) + '\n'
+        if False:
+            # FIXME: For now, tracebacks come as plain text, so we can't
+            # use the html renderer yet.  Once we refactor ultratb to
+            # produce properly styled tracebacks, this branch should be the
+            # default
+            traceback = traceback.replace(' ', '&nbsp;')
+            traceback = traceback.replace('\n', '<br/>')
+
+            ename = content['ename']
+            ename_styled = '<span class="error">%s</span>' % ename
+            traceback = traceback.replace(ename, ename_styled)
+
+            self._append_html(traceback)
         else:
-            traceback = '\n'.join(content['traceback']) + '\n'
-            if False:
-                # FIXME: For now, tracebacks come as plain text, so we can't
-                # use the html renderer yet.  Once we refactor ultratb to
-                # produce properly styled tracebacks, this branch should be the
-                # default
-                traceback = traceback.replace(' ', '&nbsp;')
-                traceback = traceback.replace('\n', '<br/>')
-
-                ename = content['ename']
-                ename_styled = '<span class="error">%s</span>' % ename
-                traceback = traceback.replace(ename, ename_styled)
-
-                self._append_html(traceback)
-            else:
-                # This is the fallback for now, using plain text with ansi
-                # escapes
-                self._append_plain_text(traceback)
+            # This is the fallback for now, using plain text with ansi
+            # escapes
+            self._append_plain_text(traceback)
 
     def _process_execute_payload(self, item):
         """ Reimplemented to dispatch payloads to handler methods.

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -292,22 +292,30 @@ class JupyterWidget(IPythonWidget):
     def _process_execute_error(self, msg):
         """Handle an execute_error message"""
         content = msg['content']
-        traceback = '\n'.join(content['traceback']) + '\n'
-        if False:
-            # FIXME: For now, tracebacks come as plain text, so we can't use
-            # the html renderer yet.  Once we refactor ultratb to produce
-            # properly styled tracebacks, this branch should be the default
-            traceback = traceback.replace(' ', '&nbsp;')
-            traceback = traceback.replace('\n', '<br/>')
 
-            ename = content['ename']
-            ename_styled = '<span class="error">%s</span>' % ename
-            traceback = traceback.replace(ename, ename_styled)
-
-            self._append_html(traceback)
+        if content['ename'] == 'KeyboardInterrupt':
+            # If the user interrupted execution by pressing CTRL-C, only
+            # display a simple message.
+            self._append_plain_text("Execution aborted\n")
         else:
-            # This is the fallback for now, using plain text with ansi escapes
-            self._append_plain_text(traceback)
+            traceback = '\n'.join(content['traceback']) + '\n'
+            if False:
+                # FIXME: For now, tracebacks come as plain text, so we can't
+                # use the html renderer yet.  Once we refactor ultratb to
+                # produce properly styled tracebacks, this branch should be the
+                # default
+                traceback = traceback.replace(' ', '&nbsp;')
+                traceback = traceback.replace('\n', '<br/>')
+
+                ename = content['ename']
+                ename_styled = '<span class="error">%s</span>' % ename
+                traceback = traceback.replace(ename, ename_styled)
+
+                self._append_html(traceback)
+            else:
+                # This is the fallback for now, using plain text with ansi
+                # escapes
+                self._append_plain_text(traceback)
 
     def _process_execute_payload(self, item):
         """ Reimplemented to dispatch payloads to handler methods.


### PR DESCRIPTION
IPython kernels no longer set the status='error' flag when executing a script using %run. Instead, a new message type 'error' is used for passing error messages around.

This PR adds a hacky fix to demonstrate the problem. Someone with a better grasp of the codebase than me should take a look and implement a clean solution.

fixes #156, #140 