### PR TITLE
[MRG] Fix "invalid cursor position" error

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -664,7 +664,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         # update output marker for stdout/stderr, so that startup
         # messages appear after banner:
-        self._append_before_prompt_pos = self._get_cursor().position()
         self._show_interpreter_prompt()
 
     def restart_kernel(self, message, now=False):

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -233,7 +233,6 @@ class JupyterWidget(IPythonWidget):
         if self.include_output(msg):
             self._append_custom(self._insert_other_input, msg['content'], before_prompt=True)
 
-    
     def _handle_execute_result(self, msg):
         """Handle an execute_result message"""
         if self.include_output(msg):


### PR DESCRIPTION
Since the `QTextEdit` object that we use as main text widget has the `maximumBlockCount` constraint set, lines of text can get removed from the beginning of the document at any time text is append to the document.

This PR fixes a particularly nasty bug where `self._append_before_prompt_pos` is incorrectly computed, leading to the `QTextCursor::setPosition: Position '14083' out of range` error.

It is important to keep proper track of the beginning and end position of the prompt, also when text is inserted or removed. Instead of manually tracking this position by computing offsets when doing text operations, this PR uses QTextCursor objects to do this.

Fixes #76, #94, #107 
