### PR TITLE
Added a basic hack to change the tab title via the display handlers.

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -164,6 +164,10 @@ class RichJupyterWidget(RichIPythonWidget):
             if 'image/svg+xml' in data:
                 svg = data['image/svg+xml']
                 self._append_svg(svg, True)
+            elif 'title' in data:
+                title = data['title']
+                tab = self.parentWidget().parentWidget()
+                tab.setTabText(tab.currentIndex(), title)
             elif 'image/png' in data:
                 # PNG data is base64 encoded as it passes over the network
                 # in a JSON structure so we decode it.


### PR DESCRIPTION
You can use the following code to change a tab's title:

    def set_title(title):
        display.display({'title':title}, raw=True)


This seems like a bit of an ugly solution, abusing the display handlers, but I figured any other solution would require adding more IPC to the code so we are better off like this.

closes #100 and #122.