### PR TITLE
Added a keyboard shortcut for renaming the current tab.

### DIFF
--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -117,7 +117,7 @@ class MainWindow(QtGui.QMainWindow):
         old_title = self.tab_widget.tabText(self.tab_widget.currentIndex())
         title, ok = QtGui.QInputDialog.getText(self,
                                                "Rename Tab",
-                                               "New Title:".format(old_title),
+                                               "New Title:",
                                                text=old_title)
         if ok:
             self.tab_widget.setTabText(self.tab_widget.currentIndex(), title)

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -117,7 +117,7 @@ class MainWindow(QtGui.QMainWindow):
         old_title = self.tab_widget.tabText(self.tab_widget.currentIndex())
         title, ok = QtGui.QInputDialog.getText(self,
                                                "Rename Tab",
-                                               "New Title:",
+                                               "New title:",
                                                text=old_title)
         if ok:
             self.tab_widget.setTabText(self.tab_widget.currentIndex(), title)

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -112,6 +112,16 @@ class MainWindow(QtGui.QMainWindow):
             name = '(%s) slave' % current_widget_name
         self.add_tab_with_frontend(widget,name=name)
 
+    def set_tab_title(self):
+        """Set the title of the current tab"""
+        old_title = self.tab_widget.tabText(self.tab_widget.currentIndex())
+        title, ok = QtGui.QInputDialog.getText(self,
+                                               "Rename Tab",
+                                               "New Title:".format(old_title),
+                                               text=old_title)
+        if ok:
+            self.tab_widget.setTabText(self.tab_widget.currentIndex(), title)
+
     def close_tab(self,current_tab):
         """ Called when you need to try to close a tab.
 
@@ -598,6 +608,13 @@ class MainWindow(QtGui.QMainWindow):
             statusTip="Select next tab",
             triggered=self.next_tab)
         self.add_menu_action(self.window_menu, self.next_tab_act)
+
+        self.rename_current_tab_act = QtGui.QAction("&Rename Current Tab",
+                                                    self,
+                                                    shortcut="Ctrl+R",
+                                                    statusTip="Rename current tab",
+                                                    triggered=self.set_tab_title)
+        self.add_menu_action(self.window_menu, self.rename_current_tab_act)
     
     def init_help_menu(self):
         # please keep the Help menu in Mac Os even if empty. It will


### PR DESCRIPTION
Added the shortcut <kbd>Ctrl+R</kbd> to rename the current tab.
It also appears in the `Window` menu.

Closes #122. Relevant to #100 as well.