### PR TITLE
Create new tab with existing kernel

### DIFF
--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -6,10 +6,12 @@ common actions.
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+import os
 import sys
 import webbrowser
 from threading import Thread
+
+from jupyter_core.paths import jupyter_runtime_dir
 
 from qtconsole.qt import QtGui,QtCore
 from qtconsole.usage import gui_reference
@@ -31,6 +33,7 @@ class MainWindow(QtGui.QMainWindow):
     def __init__(self, app,
                     confirm_exit=True,
                     new_frontend_factory=None, slave_frontend_factory=None,
+                    connection_frontend_factory=None,
                 ):
         """ Create a tabbed MainWindow for managing FrontendWidgets
         
@@ -54,6 +57,7 @@ class MainWindow(QtGui.QMainWindow):
         self.confirm_exit = confirm_exit
         self.new_frontend_factory = new_frontend_factory
         self.slave_frontend_factory = slave_frontend_factory
+        self.connection_frontend_factory = connection_frontend_factory
 
         self.tab_widget = QtGui.QTabWidget(self)
         self.tab_widget.setDocumentMode(True)
@@ -108,6 +112,17 @@ class MainWindow(QtGui.QMainWindow):
                                                text=old_title)
         if ok:
             self.setWindowTitle(title)
+
+    def create_tab_with_existing_kernel(self):
+        name, ok = QtGui.QInputDialog.getText(self,
+                                               "Connect to Existing Kernel",
+                                               "Kernel name:")
+        if not ok:
+            return
+        connection_file = os.path.join(jupyter_runtime_dir(), name)
+        widget = self.connection_frontend_factory(connection_file)
+        name = 'bla'
+        self.add_tab_with_frontend(widget, name=name)
 
     def create_tab_with_current_kernel(self):
         """create a new frontend attached to the same kernel as the current tab"""
@@ -372,6 +387,12 @@ class MainWindow(QtGui.QMainWindow):
             shortcut="Ctrl+Shift+T",
             triggered=self.create_tab_with_current_kernel)
         self.add_menu_action(self.file_menu, self.slave_kernel_tab_act)
+
+        self.existing_kernel_tab_act = QtGui.QAction("New Tab with &Existing kernel",
+                                                     self,
+                                                     shortcut="Alt+T",
+                                                     triggered=self.create_tab_with_existing_kernel)
+        self.add_menu_action(self.file_menu, self.existing_kernel_tab_act)
 
         self.file_menu.addSeparator()
 

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -6,7 +6,6 @@ common actions.
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import os
 import sys
 import webbrowser
 from threading import Thread

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -53,6 +53,7 @@ class MainWindow(QtGui.QMainWindow):
 
         super(MainWindow, self).__init__()
         self._kernel_counter = 0
+        self._external_kernel_counter = 0
         self._app = app
         self.confirm_exit = confirm_exit
         self.new_frontend_factory = new_frontend_factory
@@ -95,6 +96,13 @@ class MainWindow(QtGui.QMainWindow):
         return c
 
     @property
+    def next_external_kernel_id(self):
+        """constantly increasing counter for external kernel IDs"""
+        c = self._external_kernel_counter
+        self._external_kernel_counter += 1
+        return c
+
+    @property
     def active_frontend(self):
         return self.tab_widget.currentWidget()
 
@@ -114,14 +122,15 @@ class MainWindow(QtGui.QMainWindow):
             self.setWindowTitle(title)
 
     def create_tab_with_existing_kernel(self):
-        name, ok = QtGui.QInputDialog.getText(self,
-                                               "Connect to Existing Kernel",
-                                               "Kernel name:")
-        if not ok:
+        """create a new frontend attached to an external kernel in a new tab"""
+        connection_file, file_type = QtGui.QFileDialog.getOpenFileName(self,
+                                                     "Connect to Existing Kernel",
+                                                     jupyter_runtime_dir(),
+                                                     "Connection file (*.json)")
+        if not connection_file:
             return
-        connection_file = os.path.join(jupyter_runtime_dir(), name)
         widget = self.connection_frontend_factory(connection_file)
-        name = 'bla'
+        name = "external {}".format(self.next_external_kernel_id)
         self.add_tab_with_frontend(widget, name=name)
 
     def create_tab_with_current_kernel(self):

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -209,11 +209,11 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def new_frontend_connection(self, connection_file):
         """Create and return a new frontend attached to an existing kernel.
 
-                Parameters
-                ----------
-                connection_file : str
-                    The connection_file path this frontend is to connect to
-                """
+        Parameters
+        ----------
+        connection_file : str
+            The connection_file path this frontend is to connect to
+        """
         kernel_client = self.kernel_client_class(
             connection_file=connection_file,
             config=self.config,

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -206,6 +206,31 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         widget._display_banner = self.display_banner
         return widget
 
+    def new_frontend_connection(self, connection_file):
+        """Create and return a new frontend attached to an existing kernel.
+
+                Parameters
+                ----------
+                connection_file : str
+                    The connection_file path this frontend is to connect to
+                """
+        kernel_client = self.kernel_client_class(
+            connection_file=connection_file,
+            config=self.config,
+        )
+        kernel_client.load_connection_file()
+        kernel_client.start_channels()
+        widget = self.widget_factory(config=self.config,
+                                     local_kernel=False)
+        self.init_colors(widget)
+        widget._existing = True
+        widget._may_close = False
+        widget._confirm_exit = False
+        widget._display_banner = self.display_banner
+        widget.kernel_client = kernel_client
+        widget.kernel_manager = None
+        return widget
+
     def new_frontend_slave(self, current_widget):
         """Create and return a new frontend attached to an existing kernel.
         
@@ -260,6 +285,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
                                 confirm_exit=self.confirm_exit,
                                 new_frontend_factory=self.new_frontend_master,
                                 slave_frontend_factory=self.new_frontend_slave,
+                                connection_frontend_factory=self.new_frontend_connection,
                                 )
         self.window.log = self.log
         self.window.add_tab_with_frontend(self.widget)


### PR DESCRIPTION
Fixes #101 

The code does what is should, but I have 2 issues that need to be addressed:
1. Choosing the kernel. Currently you just enter the kernel name (from the `--existing` option). We might want something more user friendly,
2. Naming the new tab - should it be automatic ("external 0", "external 1" and so on) or user defined?
