### PR TITLE
Do not block event loop

### DIFF
--- a/qtconsole/base_frontend_mixin.py
+++ b/qtconsole/base_frontend_mixin.py
@@ -1,6 +1,5 @@
 """Defines a convenient mix-in class for implementing Qt frontends."""
 
-from jupyter_client import BlockingKernelClient
 
 class BaseFrontendMixin(object):
     """ A mix-in class for implementing Qt frontends.
@@ -15,7 +14,6 @@ class BaseFrontendMixin(object):
     #---------------------------------------------------------------------------
     _kernel_client = None
     _kernel_manager = None
-    _blocking_client = None
 
     @property
     def kernel_client(self):
@@ -64,29 +62,6 @@ class BaseFrontendMixin(object):
         # we connected.
         if kernel_client.channels_running:
             self._started_channels()
-    
-    def _make_blocking_client(self):
-        kc = self.kernel_client
-        if kc is None:
-            return
-        
-        try:
-            blocking_client = kc.blocking_client
-        except AttributeError:
-            def blocking_client():
-                info = kc.get_connection_info()
-                bc = BlockingKernelClient(**info)
-                bc.session.key = kc.session.key
-                return bc
-
-        self._blocking_client = blocking_client()
-        self._blocking_client.shell_channel.start()
-    
-    @property
-    def blocking_client(self):
-        if self._blocking_client is None:
-            self._make_blocking_client()
-        return self._blocking_client
 
     @property
     def kernel_manager(self):

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1757,7 +1757,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         cursor.setPosition(position)
         return cursor
 
-    def _insert_continuation_prompt(self, cursor):
+    def _insert_continuation_prompt(self, cursor, indent=''):
         """ Inserts new continuation prompt using the specified cursor.
         """
         if self._continuation_prompt_html is None:
@@ -1765,6 +1765,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         else:
             self._continuation_prompt = self._insert_html_fetching_plain_text(
                 cursor, self._continuation_prompt_html)
+        if indent:
+            cursor.insertText(indent)
 
     def _insert_block(self, cursor, block_format=None):
         """ Inserts an empty QTextBlock using the specified cursor.

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -565,8 +565,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
     def _trigger_is_complete_callback(self, complete=False, indent=u''):
         if self._is_complete_msg_id is not None:
+            self._is_complete_msg_id = None
             self._is_complete_callback(complete, indent)
-            self._is_complete_msg_id = self._is_complete_callback = None
 
     def _register_is_complete_callback(self, source, callback):
         self._trigger_is_complete_callback()

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -344,13 +344,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         return super(FrontendWidget, self)._event_filter_console_keypress(event)
 
-    def _insert_continuation_prompt(self, cursor, indent=''):
-        """ Reimplemented for auto-indentation.
-        """
-        super(FrontendWidget, self)._insert_continuation_prompt(cursor)
-        if indent:
-            cursor.insertText(indent)
-
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface
     #---------------------------------------------------------------------------

--- a/qtconsole/history_console_widget.py
+++ b/qtconsole/history_console_widget.py
@@ -36,17 +36,13 @@ class HistoryConsoleWidget(ConsoleWidget):
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
     #---------------------------------------------------------------------------
+    def do_execute(self, source, complete, indent):
+        """ Reimplemented to the store history. """
+        history = self.input_buffer if source is None else source
 
-    def execute(self, source=None, hidden=False, interactive=False):
-        """ Reimplemented to the store history.
-        """
-        if not hidden:
-            history = self.input_buffer if source is None else source
+        super(HistoryConsoleWidget, self).do_execute(source, complete, indent)
 
-        executed = super(HistoryConsoleWidget, self).execute(
-            source, hidden, interactive)
-
-        if executed and not hidden:
+        if complete:
             # Save the command unless it was an empty string or was identical
             # to the previous command.
             history = history.rstrip()
@@ -58,8 +54,6 @@ class HistoryConsoleWidget(ConsoleWidget):
 
             # Move the history index to the most recent item.
             self._history_index = len(self._history)
-
-        return executed
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' abstract interface

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -195,7 +195,7 @@ class TestConsoleWidget(unittest.TestCase):
         w._handle_is_complete_reply(
             dict(parent_header=dict(msg_id=msg_id),
                  content=dict(status="incomplete", indent="!!!")))
-        self.assert_text_equal(cursor, "thing\u2029> !!!")
+        self.assert_text_equal(cursor, u"thing\u2029> !!!")
         self.assertEqual(calls, [])
 
         # test complete statement (_execute called)
@@ -208,17 +208,17 @@ class TestConsoleWidget(unittest.TestCase):
                  content=dict(status="complete", indent="###")))
         self.assertEqual(calls, [("else", False)])
         calls = []
-        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029")
+        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029")
 
         # test missing answer from is_complete
         msg_id = object()
         w.execute("done", interactive=True)
         self.assertEqual(calls, ["done"])
         calls = []
-        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029")
+        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029")
         event = QtCore.QEvent(QtCore.QEvent.User)
         w.eventFilter(w, event)
-        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029\u2029> ")
+        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029\u2029> ")
 
         # assert that late answer isn't destroying anything
         w._handle_is_complete_reply(


### PR DESCRIPTION
As elaborated in #174, qtconsole blocks the event loop trying to figure out whether a command is complete. This PR fixes that: it introduces a complete callback mechanism instead. When we want to know whether a command is complete, we send it to the kernel, and register a callback for the response.

If the kernel does not respond until the user wants to continue editing, we simply assume that the code was not complete.

This PR also removes the code for creating a blocking client, as this is not needed anymore.

Closes #174 