### PR TITLE
Fix PyQt import checks on Python 3.5

### DIFF
--- a/qtconsole/qt_loaders.py
+++ b/qtconsole/qt_loaders.py
@@ -185,8 +185,6 @@ def has_binding_new(api):
                 # Submodule (e.g. PyQt5.QtCore) not found
                 return False
 
-    print(module_name, 'has required submods')
-
     if api == QT_API_PYSIDE:
         # We can also safely check PySide version
         import PySide


### PR DESCRIPTION
This provides a new implementation for Python >= 3.4, leaving the existing one for Python <= 3.3.

Closes gh-168 (hopefully; I can't reproduce it to test)