### PR TITLE
[MRG+1] Fix ansi color table when changing syntax styles

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -374,7 +374,7 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
 
     def set_background_color(self, style):
         """
-        Given a syntex style, attempt to set a color map that will be
+        Given a syntax style, attempt to set a color map that will be
         aesthetically pleasing.
         """
         # Set a new default color map.

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -13,6 +13,7 @@ from qtconsole.qt import QtGui
 
 # Local imports
 from ipython_genutils.py3compat import string_types
+from qtconsole.styles import dark_style
 
 #-----------------------------------------------------------------------------
 # Constants and datatypes
@@ -371,14 +372,15 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
 
         return format
 
-    def set_background_color(self, color):
-        """ Given a background color (a QColor), attempt to set a color map
-            that will be aesthetically pleasing.
+    def set_background_color(self, style):
+        """
+        Given a syntex style, attempt to set a color map that will be
+        aesthetically pleasing.
         """
         # Set a new default color map.
         self.default_color_map = self.darkbg_color_map.copy()
 
-        if color.value() >= 127:
+        if not dark_style(style):
             # Colors appropriate for a terminal with a light background. For
             # now, only use non-bright colors...
             for i in range(8):

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -534,8 +534,6 @@ class JupyterWidget(IPythonWidget):
         self.setStyleSheet(self.style_sheet)
         if self._control is not None:
             self._control.document().setDefaultStyleSheet(self.style_sheet)
-            bg_color = self._control.palette().window().color()
-            self._ansi_processor.set_background_color(bg_color)
         
         if self._page_control is not None:
             self._page_control.document().setDefaultStyleSheet(self.style_sheet)
@@ -548,6 +546,7 @@ class JupyterWidget(IPythonWidget):
             return
         if self.syntax_style:
             self._highlighter.set_style(self.syntax_style)
+            self._ansi_processor.set_background_color(self.syntax_style)
         else:
             self._highlighter.set_style_sheet(self.style_sheet)
 

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -1,0 +1,39 @@
+import unittest
+
+from qtconsole.qt import QtGui
+from qtconsole.qt_loaders import load_qtest
+
+from qtconsole.jupyter_widget import JupyterWidget
+import ipython_genutils.testing.decorators as dec
+
+setup = dec.skip_file_no_x11(__name__)
+QTest = load_qtest()
+
+class TestConsoleWidget(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """ Create the application for the test case.
+        """
+        cls._app = QtGui.QApplication.instance()
+        if cls._app is None:
+            cls._app = QtGui.QApplication([])
+        cls._app.setQuitOnLastWindowClosed(False)
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Exit the application.
+        """
+        QtGui.QApplication.quit()
+
+    def test_stylesheet_changed(self):
+        """ Test changing stylesheets.
+        """
+        w = JupyterWidget(kind='rich')
+
+        # By default, the background is light. White text is rendered as black
+        self.assertEqual(w._ansi_processor.get_color(15).name(), '#000000')
+
+        # Change to a dark colorscheme. White text is rendered as white
+        w.syntax_style = 'monokai'
+        self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')

--- a/qtconsole/tests/test_styles.py
+++ b/qtconsole/tests/test_styles.py
@@ -1,0 +1,14 @@
+import unittest
+from qtconsole.styles import dark_color, dark_style
+
+
+class TestStyles(unittest.TestCase):
+    def test_dark_color(self):
+        self.assertTrue(dark_color('#000000'))  # black
+        self.assertTrue(not dark_color('#ffff66'))  # bright yellow
+        self.assertTrue(dark_color('#80807f'))  # < 50% gray
+        self.assertTrue(not dark_color('#808080'))  # = 50% gray
+
+    def test_dark_style(self):
+        self.assertTrue(dark_style('monokai'))
+        self.assertTrue(not dark_style('default'))


### PR DESCRIPTION
When working with a light background, QtConsole changes the internal ansi color table to disable light variants of the colors, which would be unreadable. This fixes a bug where a light background would always be detected, even when a dark style was selected.

fixes #49 