### PR TITLE
Enhance handling of input from other clients

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -495,6 +495,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         Outputs are not displayed until enter is pressed.
         """
     )
+
+    other_output_prefix = Unicode('[remote] ', config=True,
+        help="""Prefix to add to outputs coming from clients other than this one.
+
+        Only relevant if include_other_output is True.
+        """
+    )
     
     def can_copy(self):
         """ Returns whether text can be copied to the clipboard.

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -82,7 +82,6 @@ class FrontendHighlighter(PygmentsHighlighter):
         diff = len(string) - len(without_prompt)
         if diff > 0:
             self._current_offset = diff
-            # string = string[len(prompt):]
             super(FrontendHighlighter, self).highlightBlock(without_prompt)
 
     def rehighlightBlock(self, block):

--- a/qtconsole/tests/test_frontend_widget.py
+++ b/qtconsole/tests/test_frontend_widget.py
@@ -1,0 +1,96 @@
+import unittest
+
+from qtconsole.qt import QtGui
+from qtconsole.qt_loaders import load_qtest
+from qtconsole.frontend_widget import FrontendWidget
+import ipython_genutils.testing.decorators as dec
+
+setup = dec.skip_file_no_x11(__name__)
+QTest = load_qtest()
+
+
+class TestFrontendWidget(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """ Create the application for the test case.
+        """
+        cls._app = QtGui.QApplication.instance()
+        if cls._app is None:
+            cls._app = QtGui.QApplication([])
+        cls._app.setQuitOnLastWindowClosed(False)
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Exit the application.
+        """
+        QtGui.QApplication.quit()
+
+    def test_transform_classic_prompt(self):
+        """ Test detecting classic prompts.
+        """
+        w = FrontendWidget(kind='rich')
+        t = w._highlighter.transform_classic_prompt
+
+        # Base case
+        self.assertEqual(t('>>> test'), 'test')
+        self.assertEqual(t(' >>> test'), 'test')
+        self.assertEqual(t('\t >>> test'), 'test')
+
+        # No prompt
+        self.assertEqual(t(''), '')
+        self.assertEqual(t('test'), 'test')
+
+        # Continuation prompt
+        self.assertEqual(t('... test'), 'test')
+        self.assertEqual(t(' ... test'), 'test')
+        self.assertEqual(t('  ... test'), 'test')
+        self.assertEqual(t('\t ... test'), 'test')
+
+        # Prompts that don't match the 'traditional' prompt
+        self.assertEqual(t('>>>test'), '>>>test')
+        self.assertEqual(t('>> test'), '>> test')
+        self.assertEqual(t('...test'), '...test')
+        self.assertEqual(t('.. test'), '.. test')
+
+        # Prefix indicating input from other clients
+        self.assertEqual(t('[remote] >>> test'), 'test')
+
+        # Random other prefix
+        self.assertEqual(t('[foo] >>> test'), '[foo] >>> test')
+
+    def test_transform_ipy_prompt(self):
+        """ Test detecting IPython prompts.
+        """
+        w = FrontendWidget(kind='rich')
+        t = w._highlighter.transform_ipy_prompt
+
+        # In prompt
+        self.assertEqual(t('In [1]: test'), 'test')
+        self.assertEqual(t('In [2]: test'), 'test')
+        self.assertEqual(t('In [10]: test'), 'test')
+        self.assertEqual(t(' In [1]: test'), 'test')
+        self.assertEqual(t('\t In [1]: test'), 'test')
+
+        # No prompt
+        self.assertEqual(t(''), '')
+        self.assertEqual(t('test'), 'test')
+
+        # Continuation prompt
+        self.assertEqual(t('   ...: test'), 'test')
+        self.assertEqual(t('    ...: test'), 'test')
+        self.assertEqual(t('     ...: test'), 'test')
+        self.assertEqual(t('\t   ...: test'), 'test')
+
+        # Prompts that don't match the in-prompt
+        self.assertEqual(t('In [1]:test'), 'In [1]:test')
+        self.assertEqual(t('[1]: test'), '[1]: test')
+        self.assertEqual(t('In: test'), 'In: test')
+        self.assertEqual(t(': test'), ': test')
+        self.assertEqual(t('...: test'), '...: test')
+
+        # Prefix indicating input from other clients
+        self.assertEqual(t('[remote] In [1]: test'), 'test')
+
+        # Random other prefix
+        self.assertEqual(t('[foo] In [1]: test'), '[foo] In [1]: test')

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -2,14 +2,15 @@ import unittest
 
 from qtconsole.qt import QtGui
 from qtconsole.qt_loaders import load_qtest
-
+from qtconsole.client import QtKernelClient
 from qtconsole.jupyter_widget import JupyterWidget
 import ipython_genutils.testing.decorators as dec
 
 setup = dec.skip_file_no_x11(__name__)
 QTest = load_qtest()
 
-class TestConsoleWidget(unittest.TestCase):
+
+class TestJupyterWidget(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -37,3 +38,44 @@ class TestConsoleWidget(unittest.TestCase):
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'
         self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')
+
+    def test_other_output(self):
+        """ Test displaying output from other clients.
+        """
+        w = JupyterWidget(kind='rich')
+        w._append_plain_text('Header\n')
+        w._show_interpreter_prompt(1)
+        w.other_output_prefix = '[other] '
+        w.syntax_style = 'default'
+        control = w._control
+        document = control.document()
+
+        msg = dict(
+            execution_count=1,
+            code='a = 1 + 1\nb = range(10)',
+        )
+        w._append_custom(w._insert_other_input, msg, before_prompt=True)
+
+        self.assertEqual(document.blockCount(), 6)
+        self.assertEqual(document.toPlainText(), (
+            u'Header\n'
+            u'\n'
+            u'[other] In [1]: a = 1 + 1\n'
+            u'           ...: b = range(10)\n'
+            u'\n'
+            u'In [2]: '
+        ))
+
+        # Check proper syntax highlighting
+        self.assertEqual(document.toHtml(), (
+            u'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
+            u'<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
+            u'p, li { white-space: pre-wrap; }\n'
+            u'</style></head><body style=" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;">\n'
+            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
+            u'<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:600; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
+            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
+            u'<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
+        ))


### PR DESCRIPTION
The `c.ConsoleWidget.include_other_output = True` switch will make QtConsole display input given to the kernel that was initiated by other clients. For example, a text editor can connect to the kernel and allow users to select pieces of code and execute them (like the F9 button in Spyder and MATLAB).

This PR fixes some bugs and adds some enhancements when displaying "other_input" and "other_output".

 1. Adds an `[remote] In [n]: ` prompt for other_input and an `[remote] Out[n]: ` prompt for other_output (like jupyter-console does)
 2. Adds a configuration option `other_output_prefix` to change the `[remote] ` prefix above to something else (like jupyter-console has)
 3. Fixes the syntax highlighting of other_input. The decision on whether to highlight a block is made based on whether the block starts with a prompt. The prompt detection code has been updated to properly detect the prompt generated by other_input.
 4. After other_input is received, it includes an updated prompt number. The number of the current prompt is updated in-place to reflect this.