### PR TITLE
Fix saving HTML with inline PNG for python3

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -304,7 +304,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 image.save(buffer_, format.upper())
                 buffer_.close()
                 return '<img src="data:image/%s;base64,\n%s\n" />' % (
-                    format,re.sub(r'(.{60})',r'\1\n',str(ba.toBase64())))
+                    format,re.sub(r'(.{60})',r'\1\n', str(ba.toBase64().data().decode())))
 
         elif format == "svg":
             try:


### PR DESCRIPTION
When using python 3, saving to HTML with inline PNG images is reported broken (#51). This fixes it.

fixes #51 