### PR TITLE
[MRG+1] Update URL to ipython documentation

### DIFF
--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -704,8 +704,7 @@ class MainWindow(QtGui.QMainWindow):
         self.active_frontend._page(gui_reference)
 
     def _open_online_help(self):
-        filename="http://ipython.readthedocs.io/en/stable/"
-        webbrowser.open(filename, new=1, autoraise=True)
+        webbrowser.open("https://qtconsole.readthedocs.io", new=1, autoraise=True)
 
     def toggleMaximized(self):
         if not self.isMaximized():

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -704,7 +704,7 @@ class MainWindow(QtGui.QMainWindow):
         self.active_frontend._page(gui_reference)
 
     def _open_online_help(self):
-        filename="http://ipython.org/ipython-doc/stable/index.html"
+        filename="http://ipython.readthedocs.io/en/stable/"
         webbrowser.open(filename, new=1, autoraise=True)
 
     def toggleMaximized(self):


### PR DESCRIPTION
The previously linked page has a warning that it is obsolete and points to http://ipython.readthedocs.io/en/stable/