### PR TITLE
Initialize QImage before rendering SVG

### DIFF
--- a/qtconsole/svg.py
+++ b/qtconsole/svg.py
@@ -86,6 +86,7 @@ def svg_to_image(string, size=None):
     if size is None:
         size = renderer.defaultSize()
     image = QtGui.QImage(size, QtGui.QImage.Format_ARGB32)
+    image.fill(0)
     painter = QtGui.QPainter(image)
     renderer.render(painter)
     return image


### PR DESCRIPTION
I do not know if QImage used to automatically clear the internal buffer in the past, but it does not do so on my machine  (Fedora 25, Qt 5.7.1). Therefore SVG rendering is broken for me, because the internal QImage bufer is never cleared before being rendered upon.
This leads to all sorts of rendering artefacts  as to be expected when rendering uninitialized data. A particularly annoying case is when the allocator gives the same memory chunk to QImage for different images with transparency. The result is, as you might expect, all the images consecutively rendered into the same buffer.

I tracked the bug to `svg_to_image()` in `qtconsole/svg.py
`
The fix is very trivial, just add a line with image.fill(0) before initializing the painter.