### PR TITLE
Don't move cursor back then forward if there is no banner

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2123,8 +2123,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # We can't leave the cursor at the end of the document though, because
         # that would cause any further additions to move the cursor. Therefore,
         # we move it back one place and move it forward again at the end of
-        # this method.
-        self._append_before_prompt_cursor.setPosition(cursor.position() - 1)
+        # this method. However, we only do this if the cursor isn't already
+        # at the start of the text.
+        if cursor.position() == 0:
+            move_forward = False
+        else:
+            move_forward = True
+            self._append_before_prompt_cursor.setPosition(cursor.position())
 
         # Insert a preliminary newline, if necessary.
         if newline and cursor.position() > 0:
@@ -2151,8 +2156,10 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         self._flush_pending_stream()
         self._prompt_cursor.setPosition(self._get_end_pos() - 1)
-        self._append_before_prompt_cursor.setPosition(
-            self._append_before_prompt_cursor.position() + 1)
+
+        if move_forward:
+            self._append_before_prompt_cursor.setPosition(
+                self._append_before_prompt_cursor.position() + 1)
         self._prompt_started()
 
     #------ Signal handlers ----------------------------------------------------


### PR DESCRIPTION
If I run the following example, which has no banner:

```python
from qtconsole.inprocess import QtInProcessKernelManager
from qtconsole.rich_jupyter_widget import RichJupyterWidget


if __name__ == "__main__":

    from qtpy.QtWidgets import QApplication

    app = QApplication([''])

    kernel_manager = QtInProcessKernelManager()
    kernel_manager.start_kernel()

    kernel_client = kernel_manager.client()
    kernel_client.start_channels()

    widget = RichJupyterWidget()
    widget._display_banner = False
    widget.kernel_manager = kernel_manager
    widget.kernel_client = kernel_client
    widget.shell = kernel_manager.kernel.shell

    widget.show()
    app.exec_()
```

I get the following errors:

```
QTextCursor::setPosition: Position '-1' out of range
QTextCursor::setPosition: Position '10' out of range
```

This is because in the attached code, ``cursor.position()`` is 0 if there is no banner.

I'm not sure if there is an easy way to test for Qt warnings/errors?