### PR TITLE
Restore cursor position move before inserting prompt

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2134,7 +2134,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             move_forward = False
         else:
             move_forward = True
-            self._append_before_prompt_cursor.setPosition(cursor.position())
+            self._append_before_prompt_cursor.setPosition(cursor.position() - 1)
 
         # Insert a preliminary newline, if necessary.
         if newline and cursor.position() > 0:


### PR DESCRIPTION
This PR restores moving the cursor back one place before inserting the prompt, for situations where there _is_ already some content in the console. This fixes a regression that I believe was accidentally introduced in #224.

Post #224, I see extra console messages in my qtconsole-using application that weren't present in the 4.3.0 release:
```
QTextCursor::setPosition: Position '428' out of range
```
I also see an extra test failure that wasn't there before (the second failure below; the first is already present with the 4.3.0 release on my machine):
```
(qtconsole-testing)bash-3.2$ nosetests qtconsole/
................QTextCursor::setPosition: Position '15' out of range
F.QTextCursor::setPosition: Position '53' out of range
F........
======================================================================
FAIL: Test the event handling code for keypresses.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mdickinson/Enthought/Projects/Canopy_Geoscience/qtconsole/qtconsole/tests/test_console_widget.py", line 148, in test_keypresses
    self.assertEqual(w._get_input_buffer(), 'test in')
AssertionError: u'test inkput' != 'test in'

======================================================================
FAIL: Test the cursors that keep track of where the prompt begins and
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mdickinson/Enthought/Projects/Canopy_Geoscience/qtconsole/qtconsole/tests/test_console_widget.py", line 109, in test_prompt_cursors
    w._prompt_pos - len(w._prompt))
AssertionError: 52 != 45

----------------------------------------------------------------------
Ran 27 tests in 4.277s

FAILED (failures=2)
```

This PR fixes the test failure and the `setPosition` error messages.

Versions: Python 2.7.13, qtconsole master, pyside 1.2.2, Qt 4.8.7, OS X 10.12.5.