### PR TITLE
Create a simple example of embedding, and clarify docs.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -445,31 +445,28 @@ garbage collected until the application itself is destroyed.
 Embedding the QtConsole in a Qt application
 -------------------------------------------
 
-In order to make the QtConsole available to an external Qt GUI application (just as
-:func:`IPython.embed` enables one to embed a terminal session of IPython in a
-command-line application), there are a few options:
-
-* First start IPython, and then start the external Qt application from IPython,
-  as described above.  Effectively, this embeds your application in IPython
-  rather than the other way round.
+There are a few options to integrate the Jupyter Qt console with your own
+application:
 
 * Use :class:`qtconsole.rich_jupyter_widget.RichJupyterWidget` in your
   Qt application. This will embed the console widget in your GUI and start the
   kernel in a separate process, so code typed into the console cannot access
-  objects in your application.
+  objects in your application. See :file:`examples/embed_qtconsole.py` for an
+  example.
 
-* Start a standard IPython kernel in the process of the external Qt
-  application. See :file:`examples/Embedding/ipkernel_qtapp.py` for an example. Due
-  to IPython's two-process model, the QtConsole itself will live in another
-  process with its own QApplication, and thus cannot be embedded in the main
-  GUI.
+* Start an IPython kernel inside a PyQt application (
+  `ipkernel_qtapp.py <https://github.com/ipython/ipykernel/blob/master/examples/embedding/ipkernel_qtapp.py>`_
+  in the ``ipykernel`` repository shows how to do this). Then launch the Qt
+  console in a separate process to connect to it. This means that the console
+  will be in a separate window from your application's UI, but the code entered
+  by the user runs in your application.
 
 * Start a special IPython kernel, the
-  :class:`IPython.kernel.inprocess.ipkernel.InProcessKernel`, that allows a
-  QtConsole in the same process. See :file:`examples/Embedding/inprocess_qtconsole.py`
-  for an example. While the QtConsole can now be embedded in the main GUI, one
-  cannot connect to the kernel from other consoles as there are no real ZMQ
-  sockets anymore.
+  :class:`ipykernel.inprocess.ipkernel.InProcessKernel`, which allows a
+  QtConsole in the same process. See :file:`examples/inprocess_qtconsole.py`
+  for an example. This allows both the kernel and the console interface to be
+  part of your application, but it is not well supported. We encourage you to
+  use one of the above options instead if you can.
 
 Regressions
 ===========

--- a/examples/embed_qtconsole.py
+++ b/examples/embed_qtconsole.py
@@ -1,0 +1,50 @@
+"""An example of embedding a RichJupyterWidget in a PyQT Application.
+
+This uses a normal kernel launched as a subprocess. It shows how to shutdown
+the kernel cleanly when the application quits.
+
+To run:
+
+    python3 embed_qtconsole.py
+"""
+import sys
+from PyQt5 import QtWidgets
+
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from qtconsole.manager import QtKernelManager
+
+# The ID of an installed kernel, e.g. 'bash' or 'ir'.
+USE_KERNEL = 'python3'
+
+def make_jupyter_widget_with_kernel():
+    """Start a kernel, connect to it, and create a RichJupyterWidget to use it
+    """
+    kernel_manager = QtKernelManager(kernel_name=USE_KERNEL)
+    kernel_manager.start_kernel()
+
+    kernel_client = kernel_manager.client()
+    kernel_client.start_channels()
+
+    jupyter_widget = RichJupyterWidget()
+    jupyter_widget.kernel_manager = kernel_manager
+    jupyter_widget.kernel_client = kernel_client
+    return jupyter_widget
+
+class MainWindow(QtWidgets.QMainWindow):
+    """A window that contains a single Qt console."""
+    def __init__(self):
+        super().__init__()
+        self.jupyter_widget = make_jupyter_widget_with_kernel()
+        self.setCentralWidget(self.jupyter_widget)
+
+    def shutdown_kernel(self):
+        print('Shutting down kernel...')
+        self.jupyter_widget.kernel_client.stop_channels()
+        self.jupyter_widget.kernel_manager.shutdown_kernel()
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.aboutToQuit.connect(window.shutdown_kernel)
+    sys.exit(app.exec_())

--- a/examples/inprocess_qtconsole.py
+++ b/examples/inprocess_qtconsole.py
@@ -1,10 +1,12 @@
-"""
-An example of opening up an RichJupyterWidget in a PyQT Application, this can
-execute either stand-alone or by importing this file and calling
-inprocess_qtconsole.show().
+"""An example of embedding a RichJupyterWidget with an in-process kernel.
 
-Based on the earlier example in the IPython repository, this has
-been updated to use qtconsole.
+We recommend using a kernel in a separate process as the normal option - see
+embed_qtconsole.py for more information. In-process kernels are not well
+supported.
+
+To run this example:
+
+    python3 inprocess_qtconsole.py
 """
 
 


### PR DESCRIPTION
Starting the kernel in a separate process should be the default option for most users.

Closes gh-243