### PR TITLE
Implement Block de/indent 

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -906,7 +906,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         """ Called when the tab key is pressed. Returns whether to continue
             processing the event.
         """
-        return False
+        return True
 
     #--------------------------------------------------------------------------
     # 'ConsoleWidget' protected interface

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1731,11 +1731,18 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
     def _get_leading_spaces(self):
         """ Get the number of leading spaces of the current line.
         """
-        cur = self._get_cursor()
-        cur.select(QtGui.QTextCursor.LineUnderCursor)
-        text = cur.selectedText()[len(self._continuation_prompt):]
-        return len(text) - len(text.lstrip())
 
+        cursor = self._get_cursor()
+        start_line = cursor.blockNumber()
+        if start_line == self._get_prompt_cursor().blockNumber():
+            # first line
+            offset = len(self._prompt)
+        else:
+            # continuation
+            offset = len(self._continuation_prompt)
+        cursor.select(QtGui.QTextCursor.LineUnderCursor)
+        text = cursor.selectedText()[offset:]
+        return len(text) - len(text.lstrip())
 
     @property
     def _prompt_pos(self):

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -275,7 +275,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         self._prompt_sep = ''
         self._reading = False
         self._reading_callback = None
-        self._tab_width = 8
+        self._tab_width = 4
 
         # List of strings pending to be appended as plain text in the widget.
         # The text is not immediately inserted when available to not

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1343,24 +1343,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             elif key == QtCore.Qt.Key_Tab:
                 if not self._reading:
                     if self._tab_pressed():
-                        # real tab-key, insert four spaces
-                        step = 4 - (self._get_cursor().columnNumber() -
-                                    len(self._continuation_prompt)) % 4
-                        cursor.insertText(' '*step)
+                        self._indent(dedent=False)
                     intercepted = True
 
             elif key == QtCore.Qt.Key_Backtab:
-                cur = self._get_cursor()
-                cur.movePosition(QtGui.QTextCursor.StartOfLine)
-                cur.movePosition(QtGui.QTextCursor.Right,
-                                 QtGui.QTextCursor.MoveAnchor,
-                                 self._get_prompt_cursor().columnNumber())
-                spaces = self._get_leading_spaces()
-                step = spaces % 4
-                cur.movePosition(QtGui.QTextCursor.Right,
-                                 QtGui.QTextCursor.KeepAnchor,
-                                 min(spaces, step if step != 0 else 4))
-                cur.removeSelectedText()
+                self._indent(dedent=True)
                 intercepted = True
 
             elif key == QtCore.Qt.Key_Left:
@@ -1887,6 +1874,44 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
             cursor.setPosition(position)
         return cursor
+
+    def _indent(self, dedent=True):
+        """ Indent/Dedent current line or current text selection.
+        """
+        num_newlines = self._get_cursor().selectedText().count("\u2029")
+        save_cur = self._get_cursor()
+        cur = self._get_cursor()
+
+        # move to first line of selection, if present
+        cur.setPosition(cur.selectionStart())
+        self._control.setTextCursor(cur)
+        spaces = self._get_leading_spaces()
+        # calculate number of spaces neded to align/indent to 4-space multiple
+        step = self._tab_width - (spaces % self._tab_width)
+
+        # insertText shouldn't replace if selection is active
+        cur.clearSelection()
+
+        # indent all lines in selection (ir just current) by `step`
+        for _ in range(num_newlines+1):
+            # update underlying cursor for _get_line_start_pos
+            self._control.setTextCursor(cur)
+            # move to first non-ws char on line
+            cur.setPosition(self._get_line_start_pos())
+            if dedent:
+                spaces = min(step, self._get_leading_spaces())
+                safe_step = spaces % self._tab_width
+                cur.movePosition(QtGui.QTextCursor.Right,
+                                 QtGui.QTextCursor.KeepAnchor,
+                                 min(spaces, safe_step if safe_step != 0
+                                    else self._tab_width))
+                cur.removeSelectedText()
+            else:
+                cur.insertText(' '*step)
+            cur.movePosition(QtGui.QTextCursor.Down)
+
+        # restore cursor
+        self._control.setTextCursor(save_cur)
 
     def _insert_continuation_prompt(self, cursor, indent=''):
         """ Inserts new continuation prompt using the specified cursor.

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -277,10 +277,12 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # Perform tab completion if:
         # 1) The cursor is in the input buffer.
         # 2) There is a non-whitespace character before the cursor.
+        # 3) There is no active selection.
         text = self._get_input_buffer_cursor_line()
         if text is None:
             return False
-        complete = bool(text[:self._get_input_buffer_cursor_column()].strip())
+        non_ws_before = bool(text[:self._get_input_buffer_cursor_column()].strip())
+        complete = non_ws_before and self._get_cursor().selectedText() == ''
         if complete:
             self._complete()
         return not complete

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -248,6 +248,45 @@ class TestConsoleWidget(unittest.TestCase):
                           "'bar', 'bar', 'bar']"))
         # TODO: many more keybindings
 
+    def test_indent(self):
+        """Test the event handling code for indent/dedent keypresses ."""
+        w = ConsoleWidget()
+        w._append_plain_text('Header\n')
+        w._prompt = 'prompt>'
+        w._show_prompt()
+        control = w._control
+
+        # TAB with multiline selection should block-indent
+        w._set_input_buffer("")
+        c = control.textCursor()
+        pos=c.position()
+        w._set_input_buffer("If 1:\n    pass")
+        c.setPosition(pos, QtGui.QTextCursor.KeepAnchor)
+        control.setTextCursor(c)
+        QTest.keyClick(control, QtCore.Qt.Key_Tab)
+        self.assertEqual(w._get_input_buffer(),"    If 1:\n        pass")
+
+        # TAB with multiline selection, should block-indent to next multiple
+        # of 4 spaces, if first line has 0 < indent < 4
+        w._set_input_buffer("")
+        c = control.textCursor()
+        pos=c.position()
+        w._set_input_buffer(" If 2:\n     pass")
+        c.setPosition(pos, QtGui.QTextCursor.KeepAnchor)
+        control.setTextCursor(c)
+        QTest.keyClick(control, QtCore.Qt.Key_Tab)
+        self.assertEqual(w._get_input_buffer(),"    If 2:\n        pass")
+
+        # Shift-TAB with multiline selection should block-dedent
+        w._set_input_buffer("")
+        c = control.textCursor()
+        pos=c.position()
+        w._set_input_buffer("    If 3:\n        pass")
+        c.setPosition(pos, QtGui.QTextCursor.KeepAnchor)
+        control.setTextCursor(c)
+        QTest.keyClick(control, QtCore.Qt.Key_Backtab)
+        self.assertEqual(w._get_input_buffer(),"If 3:\n    pass")
+
     def test_complete(self):
         class TestKernelClient(object):
             def is_complete(self, source):


### PR DESCRIPTION
Here's the first cut for #249. Before merging I'd like to use it for a week or so to flush out any kinks I may have introduced, but code review and testing by other interested folks is welcome.

Intention is to:
- Preserve current indent behavior when no selection is active.
- If selection **is** active, de/indent whole block by same amount, as determined by the column of the first line in the selection (indent is still done to next 4-space boundary).

Please advise on use of existing `self._tab_width=8` vs. (the new) `self._indent_width=4`.

Also noticed the criteria for triggering completion is puzzling: https://github.com/jupyter/qtconsole/blob/8508ce1e815867743dd4bb84534ebe4cfebbdc11/qtconsole/frontend_widget.py#L279

That's *"before"* and not *"right before"* , which means that:
```
In [1]:  Foo        |
```
Hitting TAB at the "|" cursor position really does trigger completion. Odd behavior.

closes #249 