### PR TITLE
Eliminate training whitespace

### DIFF
--- a/qtconsole/base_frontend_mixin.py
+++ b/qtconsole/base_frontend_mixin.py
@@ -136,12 +136,12 @@ class BaseFrontendMixin(object):
         handler = getattr(self, '_handle_' + msg_type, None)
         if handler:
             handler(msg)
-    
+
     def from_here(self, msg):
         """Return whether a message is from this session"""
         session_id = self._kernel_client.session.session
         return msg['parent_header'].get("session", session_id) == session_id
-    
+
     def include_output(self, msg):
         """Return whether we should include a given output message"""
         if self._hidden:
@@ -150,9 +150,9 @@ class BaseFrontendMixin(object):
         if msg['msg_type'] == 'execute_input':
             # only echo inputs not from here
             return self.include_other_output and not from_here
-        
+
         if self.include_other_output:
             return True
         else:
             return from_here
-    
+

--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -33,7 +33,7 @@ def html_tableify(item_matrix, select=None, header=None , footer=None) :
             +''.join((u'<td>'+header+u'</td>')*len(item_matrix[0]))\
             +'</tr>')
 
-    if footer : 
+    if footer :
         foot = (u'<tr>'\
             +''.join((u'<td>'+footer+u'</td>')*len(item_matrix[0]))\
             +'</tr>')
@@ -42,13 +42,13 @@ def html_tableify(item_matrix, select=None, header=None , footer=None) :
             head + (u''.join(html_cols)) + foot + u'</table>')
     return html
 
-class SlidingInterval(object): 
+class SlidingInterval(object):
     """a bound interval that follows a cursor
     
     internally used to scoll the completion view when the cursor 
     try to go beyond the edges, and show '...' when rows are hidden
     """
-    
+
     _min = 0
     _max = 1
     _current = 0
@@ -59,18 +59,18 @@ class SlidingInterval(object):
         minimum. usual width will be 'width', and sticky_length 
         set when the return  interval should expand to max and min
         """
-        self._min = minimum 
+        self._min = minimum
         self._max = maximum
         self._start = 0
         self._width = width
         self._stop = self._start+self._width+1
         self._sticky_lenght = sticky_lenght
-        
+
     @property
     def current(self):
         """current cursor position"""
         return self._current
-    
+
     @current.setter
     def current(self, value):
         """set current cursor position"""
@@ -78,24 +78,24 @@ class SlidingInterval(object):
 
         self._current = current
 
-        if current > self._stop : 
+        if current > self._stop :
             self._stop = current
             self._start = current-self._width
-        elif current < self._start : 
+        elif current < self._start :
             self._start = current
             self._stop = current + self._width
 
         if abs(self._start - self._min) <= self._sticky_lenght :
             self._start = self._min
-        
+
         if abs(self._stop - self._max) <= self._sticky_lenght :
             self._stop = self._max
 
-    @property 
+    @property
     def start(self):
         """begiiing of interval to show"""
         return self._start
-        
+
     @property
     def stop(self):
         """end of interval to show"""
@@ -105,7 +105,7 @@ class SlidingInterval(object):
     def width(self):
         return self._stop - self._start
 
-    @property 
+    @property
     def nth(self):
         return self.current - self.start
 
@@ -328,7 +328,7 @@ class CompletionHtml(QtGui.QWidget):
         self._sliding_interval.current = self._index[0]
         head = None
         foot = None
-        if self._sliding_interval.start > 0 : 
+        if self._sliding_interval.start > 0 :
             head = '...'
 
         if self._sliding_interval.stop < self._sliding_interval._max:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -152,9 +152,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
     # widget (Ctrl+n, Ctrl+a, etc). Enable this if you want this widget to take
     # priority (when it has focus) over, e.g., window-level menu shortcuts.
     override_shortcuts = Bool(False)
-    
+
     # ------ Custom Qt Widgets -------------------------------------------------
-    
+
     # For other projects to easily override the Qt widgets used by the console
     # (e.g. Spyder)
     custom_control = None
@@ -495,7 +495,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
     #---------------------------------------------------------------------------
-    
+
     include_other_output = Bool(False, config=True,
         help="""Whether to include output from clients
         other than this one sharing the same kernel.
@@ -510,7 +510,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         Only relevant if include_other_output is True.
         """
     )
-    
+
     def can_copy(self):
         """ Returns whether text can be copied to the clipboard.
         """
@@ -1657,16 +1657,16 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             cursor = self._control.textCursor()
             text = self._get_block_plain_text(cursor.block())
             return text[len(prompt):]
-    
+
     def _get_input_buffer_cursor_pos(self):
         """Get the cursor position within the input buffer."""
         cursor = self._control.textCursor()
         cursor.setPosition(self._prompt_pos, QtGui.QTextCursor.KeepAnchor)
         input_buffer = cursor.selection().toPlainText()
-        
+
         # Don't count continuation prompts
         return len(input_buffer.replace('\n' + self._continuation_prompt, '\n'))
-    
+
     def _get_input_buffer_cursor_prompt(self):
         """ Returns the (plain text) prompt for line of the input buffer that
             contains the cursor, or None if there is no such line.

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -126,20 +126,20 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
     confirm_restart = Bool(True, config=True,
         help="Whether to ask for user confirmation when restarting kernel")
-    
+
     lexer_class = DottedObjectName(config=True,
         help="The pygments lexer class to use."
     )
     def _lexer_class_changed(self, name, old, new):
         lexer_class = import_item(new)
         self.lexer = lexer_class()
-    
+
     def _lexer_class_default(self):
         if py3compat.PY3:
             return 'pygments.lexers.Python3Lexer'
         else:
             return 'pygments.lexers.PythonLexer'
-    
+
     lexer = Any()
     def _lexer_default(self):
         lexer_class = import_item(self.lexer_class)
@@ -693,7 +693,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     #---------------------------------------------------------------------------
     # 'FrontendWidget' protected interface
     #---------------------------------------------------------------------------
-    
+
     def _auto_call_tip(self):
         """Trigger call tip automatically on open parenthesis
         
@@ -704,7 +704,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         if cursor.document().characterAt(cursor.position()) == '(':
             # trigger auto call tip on open paren
             self._call_tip()
-    
+
     def _call_tip(self):
         """Shows a call tip, if appropriate, at the current cursor location."""
         # Decide if it makes sense to show a call tip

--- a/qtconsole/history_console_widget.py
+++ b/qtconsole/history_console_widget.py
@@ -90,7 +90,7 @@ class HistoryConsoleWidget(ConsoleWidget):
             current_pos = c.position()
             c.movePosition(QtGui.QTextCursor.EndOfBlock)
             at_eol = (c.position() == current_pos)
-    
+
             if self._history_index == len(self._history) or \
                 not (self._history_prefix == '' and at_eol) or \
                 not (self._get_edited_history(self._history_index)[:pos] == input_buffer[:pos]):

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -151,7 +151,7 @@ class JupyterWidget(IPythonWidget):
             matches = content['matches']
             start = content['cursor_start']
             end = content['cursor_end']
-            
+
             start = max(start, 0)
             end = max(end, start)
 
@@ -563,7 +563,7 @@ class JupyterWidget(IPythonWidget):
         self.setStyleSheet(self.style_sheet)
         if self._control is not None:
             self._control.document().setDefaultStyleSheet(self.style_sheet)
-        
+
         if self._page_control is not None:
             self._page_control.document().setDefaultStyleSheet(self.style_sheet)
 

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -601,7 +601,7 @@ class MainWindow(QtGui.QMainWindow):
     def init_kernel_menu(self):
         self.kernel_menu = self.menuBar().addMenu("&Kernel")
         # Qt on OSX maps Ctrl to Cmd, and Meta to Ctrl
-        # keep the signal shortcuts to ctrl, rather than 
+        # keep the signal shortcuts to ctrl, rather than
         # platform-default like we do elsewhere.
 
         ctrl = "Meta" if sys.platform == 'darwin' else "Ctrl"
@@ -700,8 +700,8 @@ class MainWindow(QtGui.QMainWindow):
         self.add_menu_action(self.help_menu, self.online_help_action)
 
     def _set_active_frontend_focus(self):
-        # this is a hack, self.active_frontend._control seems to be 
-        # a private member. Unfortunately this is the only method 
+        # this is a hack, self.active_frontend._control seems to be
+        # a private member. Unfortunately this is the only method
         # to set focus reliably
         QtCore.QTimer.singleShot(200, self.active_frontend._control.setFocus)
 

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -347,7 +347,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         if sheet:
             widget.style_sheet = sheet
             widget._style_sheet_changed()
-            
+
 
     def init_signal(self):
         """allow clean shutdown on sigint"""

--- a/qtconsole/svg.py
+++ b/qtconsole/svg.py
@@ -54,7 +54,7 @@ def svg_to_clipboard(string):
     mime_data = QtCore.QMimeData()
     mime_data.setData('image/svg+xml', string)
     QtGui.QApplication.clipboard().setMimeData(mime_data)
-        
+
 def svg_to_image(string, size=None):
     """ Convert a SVG document to a QImage.
 

--- a/qtconsole/tests/test_kill_ring.py
+++ b/qtconsole/tests/test_kill_ring.py
@@ -70,7 +70,7 @@ class TestKillRing(unittest.TestCase):
         """
         text_edit = QtGui.QPlainTextEdit()
         ring = QtKillRing(text_edit)
-        
+
         ring.kill('foo')
         ring.kill('bar')
         ring.yank()


### PR DESCRIPTION
Get rid of all training whitespace. This gets placed by accident. Let's clean it up!

Ran the following on the source code:

    python -m autopep8 --select W2 -i qtconsole/*.py
    python -m autopep8 --select W2 -i qtconsole/tests/*.py