### PR TITLE
Change Ctrl-S-A to to select cell first, then whole document

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -846,16 +846,16 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         c.clearSelection()
         c.setPosition(self._get_prompt_cursor().position())
         c.setPosition(self._get_end_pos(),
-                                 mode=QtGui.QTextCursor.KeepAnchor)
-        new_sel_Range = c.selectionStart(), c.selectionEnd()
-        if sel_range == new_sel_Range:
+                      mode=QtGui.QTextCursor.KeepAnchor)
+        new_sel_range = c.selectionStart(), c.selectionEnd()
+        if sel_range == new_sel_range:
             # cell already selected, expand selection to whole document
-            self.select_all()
+            self.select_document()
         else:
             # set cell selection as active selection
             self._control.setTextCursor(c)
 
-    def select_all(self):
+    def select_document(self):
         """ Selects all the text in the buffer.
         """
         self._control.selectAll()

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -325,7 +325,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             selectall = "Ctrl+Shift+A"
         action.setShortcut(selectall)
         action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
-        action.triggered.connect(self.select_all)
+        action.triggered.connect(self.select_all_smart)
         self.addAction(action)
         self.select_all_action = action
 
@@ -836,6 +836,24 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
     def _decrease_font_size(self):
         self.change_font_size(-1)
+
+    def select_all_smart(self):
+        """ Select current cell, or, if already selected, the whole document.
+        """
+        c = self._get_cursor()
+        sel_range = c.selectionStart(), c.selectionEnd()
+
+        c.clearSelection()
+        c.setPosition(self._get_prompt_cursor().position())
+        c.setPosition(self._get_end_pos(),
+                                 mode=QtGui.QTextCursor.KeepAnchor)
+        new_sel_Range = c.selectionStart(), c.selectionEnd()
+        if sel_range == new_sel_Range:
+            # cell already selected, expand selection to whole document
+            self.select_all()
+        else:
+            # set cell selection as active selection
+            self._control.setTextCursor(c)
 
     def select_all(self):
         """ Selects all the text in the buffer.

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -503,7 +503,7 @@ class MainWindow(QtGui.QMainWindow):
             # Only override the default if there is a collision.
             # Qt ctrl = cmd on OSX, so the match gets a false positive on OSX.
             selectall = "Ctrl+Shift+A"
-        self.select_all_action = QtGui.QAction("Select &All",
+        self.select_all_action = QtGui.QAction("Select Cell/&All",
             self,
             shortcut=selectall,
             triggered=self.select_all_active_frontend

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -134,6 +134,31 @@ class TestConsoleWidget(unittest.TestCase):
         self.assertEqual(w._append_before_prompt_pos,
                          w._prompt_pos - len(w._prompt))
 
+    def test_select_all(self):
+        w = ConsoleWidget()
+        w._append_plain_text('Header\n')
+        w._prompt = 'prompt>'
+        w._show_prompt()
+        control = w._control
+
+        cursor = w._get_cursor()
+        w._insert_plain_text_into_buffer(cursor, "if:\n    pass")
+
+        cursor.clearSelection()
+        control.setTextCursor(cursor)
+
+        # "select all" action selects cell first
+        w.select_all_smart()
+        QTest.keyClick(control, QtCore.Qt.Key_C, QtCore.Qt.ControlModifier)
+        copied = QtGui.qApp.clipboard().text()
+        self.assertEqual(copied,  'if:\n>     pass')
+
+        # # "select all" action triggered a second time selects whole document
+        w.select_all_smart()
+        QTest.keyClick(control, QtCore.Qt.Key_C, QtCore.Qt.ControlModifier)
+        copied = QtGui.qApp.clipboard().text()
+        self.assertEqual(copied,  'Header\nprompt>if:\n>     pass')
+
     def test_keypresses(self):
         """Test the event handling code for keypresses."""
         w = ConsoleWidget()


### PR DESCRIPTION
closes #257

Hit once: select current cell
Hit again: select whole document
Hit yet again: select cell again

@ccordoba12 @takluyver @wmvanvliet