### PR TITLE
Fix behaviour of right arrow key

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1367,13 +1367,16 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     intercepted = not self._in_buffer(position - 1)
 
             elif key == QtCore.Qt.Key_Right:
-                original_block_number = cursor.blockNumber()
-                self._control.moveCursor(QtGui.QTextCursor.Right,
-                                mode=anchormode)
-                if cursor.blockNumber() != original_block_number:
+                #original_block_number = cursor.blockNumber()
+                if position == self._get_line_end_pos():
+                    cursor.movePosition(QtGui.QTextCursor.NextBlock, mode=anchormode)
+                    cursor.movePosition(QtGui.QTextCursor.Right,
+                                        mode=anchormode,
+                                        n=len(self._continuation_prompt))
+                    self._control.setTextCursor(cursor)
+                else:
                     self._control.moveCursor(QtGui.QTextCursor.Right,
-                                        n=len(self._continuation_prompt),
-                                        mode=anchormode)
+                                             mode=anchormode)
                 intercepted = True
 
             elif key == QtCore.Qt.Key_Home:

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -246,6 +246,21 @@ class TestConsoleWidget(unittest.TestCase):
         self.assertEqual(w._get_input_buffer(),
                          ("foo = ['foo', 'foo', 'foo',    \n"
                           "'bar', 'bar', 'bar']"))
+
+        # Left and right keys should respect the continuation prompt
+        w._set_input_buffer("line 1\n"
+                            "line 2\n"
+                            "line 3")
+        c = control.textCursor()
+        c.setPosition(20)  # End of line 1
+        control.setTextCursor(c)
+        QTest.keyClick(control, QtCore.Qt.Key_Right)
+        # Cursor should have moved after the continuation prompt
+        self.assertEqual(control.textCursor().position(), 23)
+        QTest.keyClick(control, QtCore.Qt.Key_Left)
+        # Cursor should have moved to the end of the previous line
+        self.assertEqual(control.textCursor().position(), 20)
+
         # TODO: many more keybindings
 
     def test_indent(self):


### PR DESCRIPTION
Currently, pressing the right arrow key when at the end of a line always moves the cursor to the end of the cell, even when the cell has multiple lines. The intended behaviour was to move the cursor to the next line (respecting the continuation prompt). See #245 for more details.

Fixes #245 