### PR TITLE
Add missing newline when printing remote results

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -125,6 +125,8 @@ class RichJupyterWidget(RichIPythonWidget):
             prompt_number = content.get('execution_count', 0)
             data = content['data']
             metadata = msg['content']['metadata']
+            if not self.from_here(msg):
+                self._append_plain_text('\n', True)
             if 'image/svg+xml' in data:
                 self._pre_image_append(msg, prompt_number)
                 self._append_svg(data['image/svg+xml'], True)


### PR DESCRIPTION
When qtconsole is mirroring another session, (e.g. `jupyter qtconsole --existing --JupyterWidget.include_other_output = True`) the output messages from the other session get printed on the same line as the input. This commit fixes that.