### PR TITLE
Fix compatibility with PySide2 on Python 2.7

### DIFF
--- a/qtconsole/qt_loaders.py
+++ b/qtconsole/qt_loaders.py
@@ -74,7 +74,7 @@ def commit_api(api):
         ID.forbid('PySide')
         ID.forbid('PyQt4')
         ID.forbid('PyQt5')
-    if api == QT_API_PYSIDE:
+    elif api == QT_API_PYSIDE:
         ID.forbid('PySide2')
         ID.forbid('PyQt4')
         ID.forbid('PyQt5')


### PR DESCRIPTION
This fixes a bug in commit_api which caused PySide2 binding to be forbidden even if the loaded API was PySide2 (I think it was just a typo in the if statement)