### PR TITLE
Check that the highlighting_on attribute exists before accessing it

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -64,7 +64,7 @@ class FrontendHighlighter(PygmentsHighlighter):
     def highlightBlock(self, string):
         """ Highlight a block of text. Reimplemented to highlight selectively.
         """
-        if not self.highlighting_on:
+        if not hasattr(self, 'highlighting_on') or not self.highlighting_on:
             return
 
         # The input to this function is a unicode string that may contain


### PR DESCRIPTION
I noticed that I occasionally get an `AttributeError` while using qtconsole:
```
Traceback (most recent call last):
  File "/build/Python/linux-x86_64/lib/python3.6/site-packages/qtconsole/frontend_widget.py", line 70, in highlightBlock
    if not self.highlighting_on:
AttributeError: 'FrontendHighlighter' object has no attribute 'highlighting_on'
```
I am guessing that this happens because some object which was not created by `FrontendHighlighter.__init__()` ends up calling FrontendHighlighter.highlightBlock(), but the `highlighting_on` attribute does not actually exist on that object. This PR should fix the problem.