### PR TITLE
[PR] Make Ctrl-D enter an EOT character if kernel is executing and input is empty

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1285,8 +1285,17 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 intercepted = True
 
             elif key == QtCore.Qt.Key_D:
-                if len(self.input_buffer) == 0:
+                if len(self.input_buffer) == 0 and not self._executing:
                     self.exit_requested.emit(self)
+                # if executing and input buffer empty
+                elif len(self._get_input_buffer(force=True)) == 0:
+                    # input a EOT ansi control character 
+                    self._control.textCursor().insertText(chr(4))
+                    new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                                QtCore.Qt.Key_Return,
+                                                QtCore.Qt.NoModifier)
+                    QtGui.qApp.sendEvent(self._control, new_event)
+                    intercepted = True
                 else:
                     new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                                 QtCore.Qt.Key_Delete,

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1289,7 +1289,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     self.exit_requested.emit(self)
                 # if executing and input buffer empty
                 elif len(self._get_input_buffer(force=True)) == 0:
-                    # input a EOT ansi control character 
+                    # input a EOT ansi control character
                     self._control.textCursor().insertText(chr(4))
                     new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                                 QtCore.Qt.Key_Return,

--- a/scripts/jupyter-qtconsole
+++ b/scripts/jupyter-qtconsole
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from qtconsole.qtconsoleapp import main
+
+if __name__ == '__main__':
+    main()

--- a/scripts/jupyter-qtconsole
+++ b/scripts/jupyter-qtconsole
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from qtconsole.qtconsoleapp import main
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Fixes #289 

This code enters an EOT character when ctrl-d is pressed if kernel is executing and input buffer is empty. This preserves ctrl-d as a delete shortcut and a close tab shortcut.

![qtcons_ctrl-d](https://user-images.githubusercontent.com/10513354/42417591-684c55de-824b-11e8-8889-2e6fdc4e91b5.gif)


