### PR TITLE
Fix PyQt5 sip module incompatibility

### DIFF
--- a/qtconsole/qt_loaders.py
+++ b/qtconsole/qt_loaders.py
@@ -267,9 +267,10 @@ def import_pyqt5():
 
     ImportErrors rasied within this function are non-recoverable
     """
-    import sip
 
     from PyQt5 import QtCore, QtSvg, QtWidgets, QtGui, QtPrintSupport
+
+    import sip
 
     # Alias PyQt-specific functions for PySide compatibility.
     QtCore.Signal = QtCore.pyqtSignal


### PR DESCRIPTION
Fixes #291 

According to the [list of PyQt incompatibilities](http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html#pyqt-v5-11) moving the `import sip` statement is sufficient (I think).