### PR TITLE
Update installation instructions for pyqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ or with a system package manager. For Windows, PyQt binary packages may be
 used.
 
 **Note:** Additional information about using a system package manager may be
-found in the [qtconsole documentation](https://qtconsole.readthedocs.io). For
-example, on Linux Debian/Ubuntu, use ``sudo apt-get install python3-pyqt5`` to
-install PyQt5, ``sudo apt-get install python-qt4`` or
-``sudo apt-get install python3-pyqt4`` to install PyQt4.
+found in the [qtconsole documentation](https://qtconsole.readthedocs.io).
+
+More installation instructions for PyQT can be found in the [PyQt5 documentation] (http://pyqt.sourceforge.net/Docs/PyQt5/installation.html) and [PyQt4 documentation](http://pyqt.sourceforge.net/Docs/PyQt4/installation.html)
+
+Source packages for Windows/Linux/MacOS can be found here: [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) and [PyQt4](https://riverbankcomputing.com/software/pyqt/download).
+
 
 ## Usage
 To run the Qt console:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ used.
 **Note:** Additional information about using a system package manager may be
 found in the [qtconsole documentation](https://qtconsole.readthedocs.io).
 
-More installation instructions for PyQT can be found in the [PyQt5 documentation] (http://pyqt.sourceforge.net/Docs/PyQt5/installation.html) and [PyQt4 documentation](http://pyqt.sourceforge.net/Docs/PyQt4/installation.html)
+More installation instructions for PyQT can be found in the [PyQt5 documentation](http://pyqt.sourceforge.net/Docs/PyQt5/installation.html) and [PyQt4 documentation](http://pyqt.sourceforge.net/Docs/PyQt4/installation.html)
 
 Source packages for Windows/Linux/MacOS can be found here: [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) and [PyQt4](https://riverbankcomputing.com/software/pyqt/download).
 


### PR DESCRIPTION
Instead of having debian package installation instructions (which are already available in the qtconsole docs), the PyQT docs have been linked for alternative ways to install pyqt. Links to both pyqt4 and pyqt5 source packages for Windows/MacOS/Linux have been added.