### PR TITLE
Cleanup deprecation warnings from to other packages and make QtConsole's own proper DeprecationWarnings

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -166,7 +166,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     # 'Object' interface
     # -------------------------------------------------------------------------
 
-    def __init__(self, *args, local_kernel=_local_kernel, **kw):
+    def __init__(self, local_kernel=_local_kernel, *args, **kw):
         super(FrontendWidget, self).__init__(*args, **kw)
         # FIXME: remove this when PySide min version is updated past 1.0.7
         # forcefully disable calltips if PySide is < 1.0.7, because they crash

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -162,11 +162,11 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     _local_kernel = False
     _highlighter = Instance(FrontendHighlighter, allow_none=True)
 
-    #---------------------------------------------------------------------------
-    # 'object' interface
-    #---------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
+    # 'Object' interface
+    # -------------------------------------------------------------------------
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args, local_kernel=_local_kernel, **kw):
         super(FrontendWidget, self).__init__(*args, **kw)
         # FIXME: remove this when PySide min version is updated past 1.0.7
         # forcefully disable calltips if PySide is < 1.0.7, because they crash
@@ -212,8 +212,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         document.contentsChange.connect(self._document_contents_change)
 
         # Set flag for whether we are connected via localhost.
-        self._local_kernel = kw.get('local_kernel',
-                                    FrontendWidget._local_kernel)
+        self._local_kernel = local_kernel
 
         # Whether or not a clear_output call is pending new output.
         self._pending_clearoutput = False

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -172,8 +172,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # forcefully disable calltips if PySide is < 1.0.7, because they crash
         if qt.QT_API == qt.QT_API_PYSIDE:
             import PySide
-            if PySide.__version_info__ < (1,0,7):
-                self.log.warn("PySide %s < 1.0.7 detected, disabling calltips" % PySide.__version__)
+            if PySide.__version_info__ < (1, 0, 7):
+                self.log.warning("PySide %s < 1.0.7 found; disabling calltips",
+                                 PySide.__version__)
                 self.enable_calltips = False
 
         # FrontendWidget protected variables.
@@ -483,7 +484,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _handle_kernel_died(self, since_last_heartbeat):
         """Handle the kernel's death (if we do not own the kernel).
         """
-        self.log.warn("kernel died: %s", since_last_heartbeat)
+        self.log.warning("kernel died: %s", since_last_heartbeat)
         if self.custom_restart:
             self.custom_restart_kernel_died.emit(since_last_heartbeat)
         else:
@@ -495,7 +496,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         There's nothing to do but show a message.
         """
-        self.log.warn("kernel restarted")
+        self.log.warning("kernel restarted")
         self._kernel_restarted_message(died=died)
         self.reset()
 

--- a/qtconsole/ipython_widget.py
+++ b/qtconsole/ipython_widget.py
@@ -1,3 +1,4 @@
 import warnings
-warnings.warn("qtconsole.ipython_widget is deprecated. use qtconsole.jupyter_widget", DeprecationWarning)
+warnings.warn("qtconsole.ipython_widget is deprecated; "
+              "use qtconsole.jupyter_widget", DeprecationWarning)
 from .jupyter_widget import *

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -13,6 +13,7 @@ from subprocess import Popen
 import sys
 import time
 from textwrap import dedent
+from warnings import warn
 
 from qtconsole.qt import QtCore, QtGui
 
@@ -585,11 +586,11 @@ class JupyterWidget(IPythonWidget):
         return "Jupyter QtConsole {version}\n".format(version=__version__)
 
 
-# clobber IPythonWidget above:
+# Clobber IPythonWidget above:
 
 class IPythonWidget(JupyterWidget):
-    """Deprecated class. Use JupyterWidget"""
+    """Deprecated class; use JupyterWidget."""
     def __init__(self, *a, **kw):
-        warn("IPythonWidget is deprecated, use JupyterWidget")
+        warn("IPythonWidget is deprecated; use JupyterWidget",
+             DeprecationWarning)
         super(IPythonWidget, self).__init__(*a, **kw)
-

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -363,11 +363,14 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         self._sigint_timer = timer
 
     def _deprecate_config(self, cfg, old_name, new_name):
-        """Warn about deprecated config"""
+        """Warn about deprecated config."""
         if old_name in cfg:
-            self.log.warn("Use %s in config, not %s. Outdated config:\n    %s",
+            self.log.warning(
+                "Use %s in config, not %s. Outdated config:\n    %s",
                 new_name, old_name,
-                '\n    '.join('{name}.{key} = {value!r}'.format(key=key, value=value, name=old_name)
+                '\n    '.join(
+                    '{name}.{key} = {value!r}'.format(key=key, value=value,
+                                                      name=old_name)
                     for key, value in self.config[old_name].items()
                 )
             )

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -413,13 +413,14 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
 
 class IPythonQtConsoleApp(JupyterQtConsoleApp):
     def __init__(self, *a, **kw):
-        warn("IPythonQtConsoleApp is deprecated, use JupyterQtConsoleApp")
+        warn("IPythonQtConsoleApp is deprecated; use JupyterQtConsoleApp",
+             DeprecationWarning)
         super(IPythonQtConsoleApp, self).__init__(*a, **kw)
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Main entry point
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def main():
     JupyterQtConsoleApp.launch_instance()

--- a/qtconsole/rich_ipython_widget.py
+++ b/qtconsole/rich_ipython_widget.py
@@ -1,3 +1,4 @@
 import warnings
-warnings.warn("qtconsole.rich_ipython_widget is deprecated. use qtconsole.rich_jupyter_widget", DeprecationWarning)
+warnings.warn("qtconsole.rich_ipython_widget is deprecated; "
+              "use qtconsole.rich_jupyter_widget", DeprecationWarning)
 from .rich_jupyter_widget import *

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -1,7 +1,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from base64 import decodestring
+from base64 import decodebytes
 import os
 import re
 from warnings import warn
@@ -131,13 +131,15 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'image/png' in data:
                 self._pre_image_append(msg, prompt_number)
-                png = decodestring(data['image/png'].encode('ascii'))
-                self._append_png(png, True, metadata=metadata.get('image/png', None))
+                png = decodebytes(data['image/png'].encode('ascii'))
+                self._append_png(png, True, metadata=metadata.get('image/png',
+                                                                  None))
                 self._append_html(self.output_sep2, True)
             elif 'image/jpeg' in data and self._jpg_supported:
                 self._pre_image_append(msg, prompt_number)
-                jpg = decodestring(data['image/jpeg'].encode('ascii'))
-                self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
+                jpg = decodebytes(data['image/jpeg'].encode('ascii'))
+                self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg',
+                                                                  None))
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
@@ -166,10 +168,10 @@ class RichJupyterWidget(RichIPythonWidget):
             elif 'image/png' in data:
                 # PNG data is base64 encoded as it passes over the network
                 # in a JSON structure so we decode it.
-                png = decodestring(data['image/png'].encode('ascii'))
+                png = decodebytes(data['image/png'].encode('ascii'))
                 self._append_png(png, True, metadata=metadata.get('image/png', None))
             elif 'image/jpeg' in data and self._jpg_supported:
-                jpg = decodestring(data['image/jpeg'].encode('ascii'))
+                jpg = decodebytes(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
             elif 'text/latex' in data and latex_to_png:
                 try:

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -1,7 +1,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from base64 import decodebytes
+from base64 import b64decode
 import os
 import re
 from warnings import warn
@@ -131,13 +131,13 @@ class RichJupyterWidget(RichIPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'image/png' in data:
                 self._pre_image_append(msg, prompt_number)
-                png = decodebytes(data['image/png'].encode('ascii'))
+                png = b64decode(data['image/png'].encode('ascii'))
                 self._append_png(png, True, metadata=metadata.get('image/png',
                                                                   None))
                 self._append_html(self.output_sep2, True)
             elif 'image/jpeg' in data and self._jpg_supported:
                 self._pre_image_append(msg, prompt_number)
-                jpg = decodebytes(data['image/jpeg'].encode('ascii'))
+                jpg = b64decode(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg',
                                                                   None))
                 self._append_html(self.output_sep2, True)
@@ -168,10 +168,10 @@ class RichJupyterWidget(RichIPythonWidget):
             elif 'image/png' in data:
                 # PNG data is base64 encoded as it passes over the network
                 # in a JSON structure so we decode it.
-                png = decodebytes(data['image/png'].encode('ascii'))
+                png = b64decode(data['image/png'].encode('ascii'))
                 self._append_png(png, True, metadata=metadata.get('image/png', None))
             elif 'image/jpeg' in data and self._jpg_supported:
-                jpg = decodebytes(data['image/jpeg'].encode('ascii'))
+                jpg = b64decode(data['image/jpeg'].encode('ascii'))
                 self._append_jpg(jpg, True, metadata=metadata.get('image/jpeg', None))
             elif 'text/latex' in data and latex_to_png:
                 try:

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -408,10 +408,11 @@ class RichJupyterWidget(RichIPythonWidget):
             image.save(filename, format)
 
 
-# clobber RichIPythonWidget above:
+# Clobber RichIPythonWidget above:
 
 class RichIPythonWidget(RichJupyterWidget):
-    """Deprecated class. Use RichJupyterWidget"""
+    """Deprecated class. Use RichJupyterWidget."""
     def __init__(self, *a, **kw):
-        warn("RichIPythonWidget is deprecated, use RichJupyterWidget")
+        warn("RichIPythonWidget is deprecated, use RichJupyterWidget",
+             DeprecationWarning)
         super(RichIPythonWidget, self).__init__(*a, **kw)


### PR DESCRIPTION
This PR was prompted by a flood of identical warnings found as part of spyder/spyder-ide#8173 and described in spyder/spyder-ide#8174 that originated due to QtConsole needing to be passed ``local_kernel`` when creating new ``FrontEndWidgets``, but that then being passed on to ``traitlets`` as unrecognized arguments which are deprecated and will soon raise an error. Therefore, @ccordoba12 requested I implement the fix I suggested here, and to my pleasant surprise everything worked; all the Spyder tests (including the ``--run-slow`` ones) passed and no DeprecationWarnings were raised.

Aside from fixing that issue, it fixes a few other DeprecationWarnings found via the Spyder test suite (I couldn't run QtConsole's own ``nose`` tests locally due to it generating a ``..........Fatal Python error: failed to get random numbers to initialize Python`` that I wasn't able to fix or work around with some naive attempts. Namely, ``logging.warn`` has long been deprecated in favor of the drop in replacement ``logging.warning``; the same is true of ``base64.decodestring`` with respect to ``base64.decodebytes``. Finally, many of QtConsole's own deprecation warnings weren't properly raised as ``Deprecation Warnings`` due to lacking the ``category`` argument, so I fixed that as well. In fact, one used ``warn()`` without ever importing it which would have likely raised an error if it was used.

I also did some opportunistic style cleanup at and near the lines changed (I didn't touch anything functional), and made the warning text of the similar/identical warnings different places consistent with one another.