### PR TITLE
pyside2 support

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -435,7 +435,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # Manually adjust the scrollbars *after* a resize event is dispatched.
         elif etype == QtCore.QEvent.Resize and not self._filter_resize:
             self._filter_resize = True
-            QtGui.QApplication.instance().sendEvent(obj, event)
+            QtGui.QApplication.sendEvent(obj, event)
             self._adjust_scrollbars()
             self._filter_resize = False
             return True
@@ -815,7 +815,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         if self.font_size:
             font.setPointSize(self.font_size)
         else:
-            font.setPointSize(QtGui.QApplication.instance().font().pointSize())
+            font.setPointSize(QtGui.QApplication.font().pointSize())
         font.setStyleHint(QtGui.QFont.TypeWriter)
         self._set_font(font)
 


### PR DESCRIPTION
https://github.com/jupyter/qtconsole/issues/279

maybe someone can test if this works with pyqt5.
Also this doesn't fully fix the issues I have with pyside2. There is still this problem:

```
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/freecad/ipython/init_gui.py", line 35, in <module>
    console = put_ipy(dock_widget, mw)
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/freecad/ipython/init_gui.py", line 22, in put_ipy
    widget = RichJupyterWidget(parent=parent)
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/qtconsole/rich_jupyter_widget.py", line 53, in __init__
    super(RichJupyterWidget, self).__init__(*args, **kw)
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/qtconsole/jupyter_widget.py", line 118, in __init__
    super(JupyterWidget, self).__init__(*args, **kw)
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/qtconsole/frontend_widget.py", line 182, in __init__
    self._call_tip_widget = CallTipWidget(self._control)
  File "/home/k/conda/envs/freecad-gcc7/lib/python3.7/site-packages/qtconsole/call_tip_widget.py", line 36, in __init__
    QtGui.QStyle.PM_ToolTipLabelFrameWidth, None, self))
RuntimeError: Internal C++ object (PySide2.QtWidgets.QStyle) already deleted.
```