### PR TITLE
Fix cursor not moving while debugging

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2086,6 +2086,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         else:
             cursor.insertText(text)
         cursor.endEditBlock()
+        
+        if self._executing and end_doc_pos - end_scroll_pos <= 1:
+            end_scroll = (self._control.verticalScrollBar().maximum()
+                          - self._control.verticalScrollBar().pageStep())
+            self._control.verticalScrollBar().setValue(end_scroll)
 
     def _insert_plain_text_into_buffer(self, cursor, text):
         """ Inserts text into the input buffer using the specified cursor (which

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2087,9 +2087,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             cursor.insertText(text)
         cursor.endEditBlock()
 
-        if self._executing and end_doc_pos - end_scroll_pos <= 1:
-            self._control.moveCursor(QtGui.QTextCursor.End)
-
     def _insert_plain_text_into_buffer(self, cursor, text):
         """ Inserts text into the input buffer using the specified cursor (which
             must be in the input buffer), ensuring that continuation prompts are

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2086,7 +2086,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         else:
             cursor.insertText(text)
         cursor.endEditBlock()
-        
+
         if self._executing and end_doc_pos - end_scroll_pos <= 1:
             end_scroll = (self._control.verticalScrollBar().maximum()
                           - self._control.verticalScrollBar().pageStep())

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -416,6 +416,11 @@ class TestConsoleWidget(unittest.TestCase):
         assert responses == [('complete', None)]
 
     def test_debug(self):
+        """
+        Make sure the cursor works while debugging 
+        
+        It might not because the console is "_executing"
+        """
         # Kernel client to test the responses of is_complete
         class TestIPyKernelClient(object):
             def is_complete(self, source):

--- a/qtconsole/tests/test_console_widget.py
+++ b/qtconsole/tests/test_console_widget.py
@@ -414,3 +414,31 @@ class TestConsoleWidget(unittest.TestCase):
         w._set_input_buffer(code)
         w.execute(interactive=True)
         assert responses == [('complete', None)]
+
+    def test_debug(self):
+        # Kernel client to test the responses of is_complete
+        class TestIPyKernelClient(object):
+            def is_complete(self, source):
+                tm = TransformerManager()
+                check_complete = tm.check_complete(source)
+                responses.append(check_complete)
+
+        # Initialize widget
+        responses = []
+        w = ConsoleWidget()
+        w._append_plain_text('Header\n')
+        w._prompt = 'prompt>'
+        w._show_prompt()
+        w.kernel_client = TestIPyKernelClient()
+        control = w._control
+
+        # Execute incomplete statement inside a block
+        code = "%debug range(1)\n"
+        w._set_input_buffer(code)
+        w.execute(interactive=True)
+
+         # We should be able to move the cursor while debugging
+        w._set_input_buffer("abd")
+        QTest.keyClick(control, QtCore.Qt.Key_Left)
+        QTest.keyClick(control, 'c')
+        self.assertEqual(w._get_input_buffer(),"abcd")


### PR DESCRIPTION
Stop the cursor from moving at the end while debugging.

Fixes #330.