### PR TITLE
PR: Add Comms to qtconsole

### DIFF
--- a/qtconsole/comms.py
+++ b/qtconsole/comms.py
@@ -1,0 +1,268 @@
+"""
+Based on
+https://github.com/jupyter/notebook/blob/master/notebook/static/services/kernels/comm.js
+https://github.com/ipython/ipykernel/blob/master/ipykernel/comm/manager.py
+https://github.com/ipython/ipykernel/blob/master/ipykernel/comm/comm.py
+
+
+Which are distributed under the terms of the Modified BSD License.
+"""
+import logging
+
+from traitlets.config import LoggingConfigurable
+
+from ipython_genutils.importstring import import_item
+from ipython_genutils.py3compat import string_types
+
+import uuid
+
+from qtconsole.qt import QtCore
+from qtconsole.util import MetaQObjectHasTraits, SuperQObject
+
+class CommManager(MetaQObjectHasTraits(
+        'NewBase', (LoggingConfigurable, SuperQObject), {})):
+    """
+    Manager for Comms in the Frontend
+    """
+    def __init__(self, kernel_client, *args, **kwargs):
+        super(CommManager, self).__init__(*args, **kwargs)
+        self.comms = {}
+        self.targets = {}
+        if kernel_client:
+            self.init_kernel_client(kernel_client)
+
+    def init_kernel_client(self, kernel_client):
+        """
+        connect the kernel, and register message handlers
+        """
+        self.kernel_client = kernel_client
+        kernel_client.iopub_channel.message_received.connect(self._dispatch)
+
+    @QtCore.Slot(object)
+    def _dispatch(self, msg):
+        """Dispatch messages"""
+        msg_type = msg['header']['msg_type']
+        handled_msg_types = ['comm_open', 'comm_msg', 'comm_close']
+        if msg_type in handled_msg_types:
+            getattr(self, msg_type)(msg)
+
+    def new_comm(self, target_name, data=None, metadata=None,
+                 comm_id=None, buffers=None):
+        """
+        Create a new Comm, register it, and open its Kernel-side counterpart
+        Mimics the auto-registration in `Comm.__init__` in the Jupyter Comm.
+        
+        argument comm_id is optional
+        """
+        comm = Comm(target_name, self.kernel_client, comm_id)
+        self.register_comm(comm)
+        try:
+            comm.open(data, metadata, buffers)
+        except:
+            self.unregister_comm(comm)
+            raise
+        return comm
+
+    def register_target(self, target_name, f):
+        """Register a callable f for a given target name
+        
+        f will be called with two arguments when a comm_open message is
+        received with `target`:
+            
+        - the Comm instance
+        - the `comm_open` message itself.
+        
+        f can be a Python callable or an import string for one.
+        """
+        if isinstance(f, string_types):
+            f = import_item(f)
+
+        self.targets[target_name] = f
+
+    def unregister_target(self, target_name, f):
+        """Unregister a callable registered with register_target"""
+        return self.targets.pop(target_name)
+
+    def register_comm(self, comm):
+        """Register a new comm"""
+        comm_id = comm.comm_id
+        comm.kernel_client = self.kernel_client
+        self.comms[comm_id] = comm
+        comm.sig_is_closing.connect(self.unregister_comm)
+        return comm_id
+
+    @QtCore.Slot(object)
+    def unregister_comm(self, comm):
+        """Unregister a comm, and close its counterpart."""
+        # unlike get_comm, this should raise a KeyError
+        comm.sig_is_closing.disconnect(self.unregister_comm)
+        self.comms.pop(comm.comm_id)
+
+    def get_comm(self, comm_id):
+        """Get a comm with a particular id
+        
+        Returns the comm if found, otherwise None.
+        
+        This will not raise an error,
+        it will log messages if the comm cannot be found.
+        """
+        try:
+            return self.comms[comm_id]
+        except KeyError:
+            self.log.warning("No such comm: %s", comm_id)
+            if self.log.isEnabledFor(logging.DEBUG):
+                # don't create the list of keys if debug messages aren't enabled
+                self.log.debug("Current comms: %s", list(self.comms.keys()))
+
+    # comm message handlers
+    def comm_open(self, msg):
+        """Handler for comm_open messages"""
+        content = msg['content']
+        comm_id = content['comm_id']
+        target_name = content['target_name']
+        f = self.targets.get(target_name, None)
+
+        comm = Comm(target_name, self.kernel_client, comm_id)
+        self.register_comm(comm)
+
+        if f is None:
+            self.log.error("No such comm target registered: %s", target_name)
+        else:
+            try:
+                f(comm, msg)
+                return
+            except Exception:
+                self.log.error("Exception opening comm with target: %s",
+                               target_name, exc_info=True)
+
+        # Failure.
+        try:
+            comm.close()
+        except:
+            self.log.error("""Could not close comm during `comm_open` failure
+                clean-up.  The comm may not have been opened yet.""",
+                exc_info=True)
+
+    def comm_close(self, msg):
+        """Handler for comm_close messages"""
+        content = msg['content']
+        comm_id = content['comm_id']
+        comm = self.get_comm(comm_id)
+        if comm is None:
+            return
+
+        self.unregister_comm(comm)
+
+        try:
+            comm.handle_close(msg)
+        except Exception:
+            self.log.error('Exception in comm_close for %s', comm_id,
+                           exc_info=True)
+
+    def comm_msg(self, msg):
+        """Handler for comm_msg messages"""
+        content = msg['content']
+        comm_id = content['comm_id']
+        comm = self.get_comm(comm_id)
+        if comm is None:
+            return
+        try:
+            comm.handle_msg(msg)
+        except Exception:
+            self.log.error('Exception in comm_msg for %s', comm_id,
+                           exc_info=True)
+
+class Comm(MetaQObjectHasTraits(
+        'NewBase', (LoggingConfigurable, SuperQObject), {})):
+    """
+    Comm base class
+    """
+    sig_is_closing = QtCore.Signal(object)
+
+    def __init__(self, target_name, kernel_client, comm_id=None,
+                 msg_callback=None, close_callback=None):
+        """
+        Create a new comm. Must call open to use.
+        """
+        super(Comm, self).__init__(target_name=target_name)
+        self.target_name = target_name
+        self.kernel_client = kernel_client
+        if comm_id is None:
+            comm_id = uuid.uuid1().hex
+        self.comm_id = comm_id
+        self._msg_callback = msg_callback
+        self._close_callback = close_callback
+        self._send_channel = self.kernel_client.shell_channel
+
+    def __del__(self):
+        self.close()
+
+    def _send_msg(self, msg_type, content, data, metadata, buffers):
+        """
+        Send a message on the shell channel.
+        """
+        if data is None:
+            data = {}
+        if content is None:
+            content = {}
+        content['comm_id'] = self.comm_id
+        content['data'] = data
+
+        msg = self.kernel_client.session.msg(
+            msg_type, content, metadata=metadata)
+        if buffers:
+            msg['buffers'] = buffers
+        return self._send_channel.send(msg)
+
+    # methods for sending messages
+    def open(self, data=None, metadata=None, buffers=None):
+        """Open the kernel-side version of this comm"""
+        return self._send_msg(
+            'comm_open', {'target_name': self.target_name},
+            data, metadata, buffers)
+
+    def send(self, data=None, metadata=None, buffers=None):
+        """Send a message to the kernel-side version of this comm"""
+        return self._send_msg(
+            'comm_msg', {}, data, metadata, buffers)
+
+    def close(self, data=None, metadata=None, buffers=None):
+        """Close the kernel-side version of this comm"""
+        self.sig_is_closing.emit(self)
+        return self._send_msg(
+            'comm_close', {}, data, metadata, buffers)
+
+    # methods for registering callbacks for incoming messages
+
+    def on_msg(self, callback):
+        """Register a callback for comm_msg
+        
+        Will be called with the `data` of any comm_msg messages.
+        
+        Call `on_msg(None)` to disable an existing callback.
+        """
+        self._msg_callback = callback
+
+    def on_close(self, callback):
+        """Register a callback for comm_close
+        
+        Will be called with the `data` of the close message.
+        
+        Call `on_close(None)` to disable an existing callback.
+        """
+        self._close_callback = callback
+    
+    # methods for handling incoming messages
+    def handle_msg(self, msg):
+        """Handle a comm_msg message"""
+        self.log.debug("handle_msg[%s](%s)", self.comm_id, msg)
+        if self._msg_callback:
+            return self._msg_callback(msg)
+
+    def handle_close(self, msg):
+        """Handle a comm_close message"""
+        self.log.debug("handle_close[%s](%s)", self.comm_id, msg)
+        if self._close_callback:
+            return self._close_callback(msg)
+
+__all__ = ['CommManager']

--- a/qtconsole/kernel_mixins.py
+++ b/qtconsole/kernel_mixins.py
@@ -7,6 +7,7 @@ from qtconsole.qt import QtCore
 
 from traitlets import HasTraits, Type
 from .util import MetaQObjectHasTraits, SuperQObject
+from .comms import CommManager
 
 
 class QtKernelRestarterMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObject), {})):
@@ -35,6 +36,9 @@ class QtKernelClientMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObje
     # 'KernelClient' interface
     #---------------------------------------------------------------------------
 
+    def __init__(self, *args, **kwargs):
+        super(QtKernelClientMixin, self).__init__(*args, **kwargs)
+        self.comm_manager = None
     #------ Channel management -------------------------------------------------
 
     def start_channels(self, *args, **kw):
@@ -42,9 +46,11 @@ class QtKernelClientMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObje
         """
         super(QtKernelClientMixin, self).start_channels(*args, **kw)
         self.started_channels.emit()
+        self.comm_manager = CommManager(parent=self, kernel_client=self)
 
     def stop_channels(self):
         """ Reimplemented to emit signal.
         """
         super(QtKernelClientMixin, self).stop_channels()
         self.stopped_channels.emit()
+        self.comm_manager = None

--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -1,0 +1,154 @@
+import time
+import sys
+
+import unittest
+
+from jupyter_client.blocking.channels import Empty
+
+from qtconsole.manager import QtKernelManager
+
+PY2 = sys.version[0] == '2'
+if PY2:
+    TimeoutError = RuntimeError
+
+class Tests(unittest.TestCase):
+
+    def setUp(self):
+        """Open a kernel."""
+        self.kernel_manager = QtKernelManager()
+        self.kernel_manager.start_kernel()
+        self.kernel_client = self.kernel_manager.client()
+        self.kernel_client.start_channels(shell=True, iopub=True)
+        self.blocking_client = self.kernel_client.blocking_client()
+        self.blocking_client.start_channels(shell=True, iopub=True)
+        self.comm_manager = self.kernel_client.comm_manager
+
+        # Check if client is working
+        self.blocking_client.execute('print(0)')
+        try:
+            self._get_next_msg()
+            self._get_next_msg()
+        except TimeoutError:
+            # Maybe it works now?
+            self.blocking_client.execute('print(0)')
+            self._get_next_msg()
+            self._get_next_msg()
+
+
+    def tearDown(self):
+        """Close the kernel."""
+        if self.kernel_manager:
+            self.kernel_manager.shutdown_kernel(now=True)
+        if self.kernel_client:
+            self.kernel_client.shutdown()
+
+    def _get_next_msg(self, timeout=10):
+        # Get status messages
+        timeout_time = time.time() + timeout
+        msg_type = 'status'
+        while msg_type == 'status':
+            if timeout_time < time.time():
+                raise TimeoutError
+            try:
+                msg = self.blocking_client.get_iopub_msg(timeout=3)
+                msg_type = msg['header']['msg_type']
+            except Empty:
+                pass
+        return msg
+    
+    def test_kernel_to_frontend(self):
+        """Communicate from the kernel to the frontend."""
+        comm_manager = self.comm_manager
+        blocking_client = self.blocking_client
+
+        class DummyCommHandler():
+            def __init__(self):
+                comm_manager.register_target('test_api', self.comm_open)
+                self.last_msg = None
+        
+            def comm_open(self, comm, msg):
+                comm.on_msg(self.comm_message)
+                comm.on_close(self.comm_message)
+                self.last_msg = msg['content']['data']
+                self.comm = comm
+        
+            def comm_message(self, msg):
+                self.last_msg = msg['content']['data']
+        
+        handler = DummyCommHandler()
+        blocking_client.execute(
+        "from ipykernel.comm import Comm\n"
+        "comm = Comm(target_name='test_api', data='open')\n"
+        "comm.send('message')\n"
+        "comm.close('close')\n"
+        "del comm\n"
+        "print('Done')\n"
+        )
+        # Get input
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'execute_input'
+        # Open comm
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'comm_open'
+        comm_manager._dispatch(msg)
+        assert handler.last_msg == 'open'
+        assert handler.comm.comm_id == msg['content']['comm_id']
+        # Get message
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'comm_msg'
+        comm_manager._dispatch(msg)
+        assert handler.last_msg == 'message'
+        assert handler.comm.comm_id == msg['content']['comm_id']
+        # Get close
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'comm_close'
+        comm_manager._dispatch(msg)
+        assert handler.last_msg == 'close'
+        assert handler.comm.comm_id == msg['content']['comm_id']
+        # Get close
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'stream'
+
+    def test_frontend_to_kernel(self):
+        """Communicate from the frontend to the kernel."""
+        comm_manager = self.comm_manager
+        blocking_client = self.blocking_client
+        blocking_client.execute(
+            "class DummyCommHandler():\n"
+            "    def __init__(self):\n"
+            "        get_ipython().kernel.comm_manager.register_target(\n"
+            "            'test_api', self.comm_open)\n"
+            "    def comm_open(self, comm, msg):\n"
+            "        comm.on_msg(self.comm_message)\n"
+            "        comm.on_close(self.comm_message)\n"
+            "        print(msg['content']['data'])\n"
+            "    def comm_message(self, msg):\n"
+            "        print(msg['content']['data'])\n"
+            "dummy = DummyCommHandler()\n"
+        )
+        # Get input
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'execute_input'
+        # Open comm
+        comm = comm_manager.new_comm('test_api', data='open')
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'stream'
+        assert msg['content']['text'] == 'open\n'
+        # Get message
+        comm.send('message')
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'stream'
+        assert msg['content']['text'] == 'message\n'
+        # Get close
+        comm.close('close')
+        msg = self._get_next_msg()
+        # For some reason ipykernel notifies me that it is closing,
+        # even though I closed the comm
+        assert msg['header']['msg_type'] == 'comm_close'
+        assert comm.comm_id == msg['content']['comm_id']
+        msg = self._get_next_msg()
+        assert msg['header']['msg_type'] == 'stream'
+        assert msg['content']['text'] == 'close\n'
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add comms to qtconsole.

This is based on:
https://jupyter-notebook.readthedocs.io/en/stable/comms.html
https://jupyter-client.readthedocs.io/en/latest/messaging.html

The code is adapted from:
https://github.com/jupyter/notebook/blob/master/notebook/static/services/kernels/comm.js
https://github.com/ipython/ipykernel/blob/master/ipykernel/comm/manager.py
https://github.com/ipython/ipykernel/blob/master/ipykernel/comm/comm.py