### PR TITLE
PR: Inherit console widget style and handle cursor position in the completion widget

### DIFF
--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -296,12 +296,15 @@ class CompletionHtml(QtGui.QWidget):
         r, c = self._index
         self._select_index(r, c+1)
 
-    def show_items(self, cursor, items):
+    def show_items(self, cursor, items, prefix_length=0):
         """ Shows the completion widget with 'items' at the position specified
             by 'cursor'.
         """
         if not items :
             return
+        # Move cursor to start of the prefix to replace it
+        # when a item is selected
+        cursor.movePosition(QtGui.QTextCursor.Left, n=prefix_length)
         self._start_position = cursor.position()
         self._consecutive_tab = 1
         # Calculate the number of characters available.

--- a/qtconsole/completion_plain.py
+++ b/qtconsole/completion_plain.py
@@ -46,7 +46,7 @@ class CompletionPlain(QtGui.QWidget):
         self._console_widget._clear_temporary_buffer()
 
 
-    def show_items(self, cursor, items):
+    def show_items(self, cursor, items, prefix_length=0):
         """ Shows the completion widget with 'items' at the position specified
             by 'cursor'.
         """
@@ -54,4 +54,7 @@ class CompletionPlain(QtGui.QWidget):
             return
         self.cancel_completion()
         strng = text.columnize(items)
+        # Move cursor to start of the prefix to replace it
+        # when a item is selected
+        cursor.movePosition(QtGui.QTextCursor.Left, n=prefix_length)
         self._console_widget._fill_temporary_buffer(cursor, strng, html=False)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -102,7 +102,7 @@ class CompletionWidget(QtGui.QListWidget):
             by 'cursor'.
         """
         text_edit = self._text_edit
-        point = self._get_position_point(cursor)
+        point = self._get_top_left_position(cursor)
         self.clear()
         for item in items:
             list_item = QtGui.QListWidgetItem()
@@ -131,8 +131,8 @@ class CompletionWidget(QtGui.QListWidget):
     # Protected interface
     #--------------------------------------------------------------------------
 
-    def _get_position_point(self, cursor):
-        """ Get point of start of the widget.
+    def _get_top_left_position(self, cursor):
+        """ Get top left position for this widget.
         """
         point = self._text_edit.cursorRect(cursor).center()
         point_size = self._text_edit.font().pointSize()
@@ -172,7 +172,7 @@ class CompletionWidget(QtGui.QListWidget):
         """
         # Update widget position
         cursor = self._text_edit.textCursor()
-        point = self._get_position_point(cursor)
+        point = self._get_top_left_position(cursor)
         self.move(point)
 
         # Update current item

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -102,7 +102,11 @@ class CompletionWidget(QtGui.QListWidget):
         point = text_edit.cursorRect(cursor).bottomRight()
         point = text_edit.mapToGlobal(point)
         self.clear()
-        self.addItems(items)
+        for item in items:
+            list_item = QtGui.QListWidgetItem()
+            list_item.setData(QtCore.Qt.UserRole, item)
+            list_item.setText(item.split('.')[-1])
+            self.addItem(list_item)
         height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
         if (screen_rect.size().height() + screen_rect.y() -
@@ -128,7 +132,8 @@ class CompletionWidget(QtGui.QListWidget):
     def _complete_current(self):
         """ Perform the completion with the currently selected item.
         """
-        self._current_text_cursor().insertText(self.currentItem().text())
+        text = self.currentItem().data(QtCore.Qt.UserRole)
+        self._current_text_cursor().insertText(text)
         self.hide()
 
     def _current_text_cursor(self):

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -1,5 +1,8 @@
 """A dropdown completer widget for the qtconsole."""
 
+import os
+import sys
+
 from qtconsole.qt import QtCore, QtGui
 
 
@@ -99,8 +102,7 @@ class CompletionWidget(QtGui.QListWidget):
             by 'cursor'.
         """
         text_edit = self._text_edit
-        point = text_edit.cursorRect(cursor).bottomRight()
-        point = text_edit.mapToGlobal(point)
+        point = self._get_position_point(cursor)
         self.clear()
         for item in items:
             list_item = QtGui.QListWidgetItem()
@@ -129,6 +131,24 @@ class CompletionWidget(QtGui.QListWidget):
     # Protected interface
     #--------------------------------------------------------------------------
 
+    def _get_position_point(self, cursor):
+        """ Get point of start of the widget.
+        """
+        point = self._text_edit.cursorRect(cursor).center()
+        point_size = self._text_edit.font().pointSize()
+
+        if sys.platform == 'darwin':
+            delta = int((point_size * 1.20) ** 0.98)
+        elif os.name == 'nt':
+            delta = int((point_size * 1.20) ** 1.05)
+        else:
+            delta = int((point_size * 1.20) ** 0.98)
+
+        y = delta - (point_size / 2)
+        point.setY(point.y() + y)
+        point = self._text_edit.mapToGlobal(point)
+        return point
+
     def _complete_current(self):
         """ Perform the completion with the currently selected item.
         """
@@ -152,9 +172,8 @@ class CompletionWidget(QtGui.QListWidget):
         """
         # Update widget position
         cursor = self._text_edit.textCursor()
-        point = self._text_edit.cursorRect(cursor).bottomRight()
-        position = self._text_edit.mapToGlobal(point)
-        self.move(position)
+        point = self._get_position_point(cursor)
+        self.move(point)
 
         # Update current item
         prefix = self._current_text_cursor().selection().toPlainText()

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1022,9 +1022,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 cursor.insertText(prefix)
                 current_pos = cursor.position()
 
-            cursor.movePosition(QtGui.QTextCursor.Left, n=len(prefix))
-            self._completion_widget.show_items(cursor, items)
-
+            self._completion_widget.show_items(cursor, items,
+                                               prefix_length=len(prefix))
 
     def _fill_temporary_buffer(self, cursor, text, html=False):
         """fill the area below the active editting zone with text"""


### PR DESCRIPTION
Fixes spyder-ide/spyder#9594

![console](https://user-images.githubusercontent.com/16781833/61340146-ac918980-a806-11e9-95d8-df29b242ff3c.gif)

