### PR TITLE
Scroll down for output from remote command

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -944,7 +944,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         # Perform the insertion.
         result = insert(cursor, input, *args, **kwargs)
-
+        self._control.moveCursor(QtGui.QTextCursor.End)
         return result
 
     def _append_block(self, block_format=None, before_prompt=False):


### PR DESCRIPTION
Fixes #347 

Explanation
Qtconsole treats commands from an external frontend (remote) differently than commands done locally. However all remote commands go through the function "_append_custom" where I added the line to scroll to the end of the console.

![scroll_output](https://user-images.githubusercontent.com/15875771/60537843-64874880-9cd7-11e9-8ef7-1c90d3fe3d2f.gif)
