### PR TITLE
Remove deprecation warnings in Python 3.8

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -490,7 +490,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         if self.paging == 'vsplit':
             height = height * 2 + splitwidth
 
-        return QtCore.QSize(width, height)
+        return QtCore.QSize(int(width), int(height))
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
@@ -2403,13 +2403,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             maximum = document.size().height()
             step = viewport_height
         diff = maximum - scrollbar.maximum()
-        scrollbar.setRange(0, maximum)
-        scrollbar.setPageStep(step)
+        scrollbar.setRange(0, round(maximum))
+        scrollbar.setPageStep(round(step))
 
         # Compensate for undesirable scrolling that occurs automatically due to
         # maximumBlockCount() text truncation.
         if diff < 0 and document.blockCount() == document.maximumBlockCount():
-            scrollbar.setValue(scrollbar.value() + diff)
+            scrollbar.setValue(round(scrollbar.value() + diff))
 
     def _custom_context_menu_requested(self, pos):
         """ Shows a context menu at the given QPoint (in widget coordinates).

--- a/qtconsole/manager.py
+++ b/qtconsole/manager.py
@@ -18,7 +18,7 @@ class QtKernelRestarter(KernelRestarter, QtKernelRestarterMixin):
         if self._timer is None:
             self._timer = QtCore.QTimer()
             self._timer.timeout.connect(self.poll)
-        self._timer.start(self.time_to_dead * 1000)
+        self._timer.start(round(self.time_to_dead * 1000))
 
     def stop(self):
         self._timer.stop()


### PR DESCRIPTION
Removed some of the deprecation warnings (implicit casting to int). This gets rid of the almost 4000 warnings in Spyder related to qtconsole. 

A few more than those explicitly pointed out in the Spyder logs are fixed, but I cannot say that these are all.