### PR TITLE
Scroll when adding text even when not executing.

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2018,12 +2018,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         if buffer_size > 0:
             text = self._get_last_lines(text, buffer_size)
 
-        if self._executing:
-            viewport = self._control.viewport()
-            end_scroll_pos = self._control.cursorForPosition(
-                QtCore.QPoint(viewport.width()-1, viewport.height()-1)
-                ).position()
-            end_doc_pos = self._get_end_pos()
+        viewport = self._control.viewport()
+        end_scroll_pos = self._control.cursorForPosition(
+            QtCore.QPoint(viewport.width()-1, viewport.height()-1)
+            ).position()
+        end_doc_pos = self._get_end_pos()
 
         cursor.beginEditBlock()
         if self.ansi_codes:
@@ -2085,7 +2084,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             cursor.insertText(text)
         cursor.endEditBlock()
 
-        if self._executing and end_doc_pos - end_scroll_pos <= 1:
+        if end_doc_pos - end_scroll_pos <= 1:
             end_scroll = (self._control.verticalScrollBar().maximum()
                           - self._control.verticalScrollBar().pageStep())
             # Only scroll down


### PR DESCRIPTION
If text is added to the console, even if the console is not executing, the console should scroll.