### PR TITLE
Allow text to be added before the prompt while autocompleting

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -157,7 +157,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     exit_requested = QtCore.Signal(object)
 
     _CallTipRequest = namedtuple('_CallTipRequest', ['id', 'pos'])
-    _CompletionRequest = namedtuple('_CompletionRequest', ['id', 'pos'])
+    _CompletionRequest = namedtuple('_CompletionRequest',
+                                    ['id', 'code', 'pos'])
     _ExecutionRequest = namedtuple('_ExecutionRequest', ['id', 'kind'])
     _local_kernel = False
     _highlighter = Instance(FrontendHighlighter, allow_none=True)
@@ -727,13 +728,11 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _complete(self):
         """ Performs completion at the current cursor location.
         """
+        code = self.input_buffer
+        cursor_pos = self._get_input_buffer_cursor_pos()
         # Send the completion request to the kernel
-        msg_id = self.kernel_client.complete(
-            code=self.input_buffer,
-            cursor_pos=self._get_input_buffer_cursor_pos(),
-        )
-        pos = self._get_cursor().position()
-        info = self._CompletionRequest(msg_id, pos)
+        msg_id = self.kernel_client.complete(code=code, cursor_pos=cursor_pos)
+        info = self._CompletionRequest(msg_id, code, cursor_pos)
         self._request_info['complete'] = info
 
     def _process_execute_abort(self, msg):

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -149,8 +149,9 @@ class JupyterWidget(IPythonWidget):
         self.log.debug("complete: %s", rep.get('content', ''))
         cursor = self._get_cursor()
         info = self._request_info.get('complete')
-        if info and info.id == rep['parent_header']['msg_id'] and \
-                info.pos == cursor.position():
+        if (info and info.id == rep['parent_header']['msg_id']
+                and info.pos == self._get_input_buffer_cursor_pos()
+                and info.code == self.input_buffer):
             content = rep['content']
             matches = content['matches']
             start = content['cursor_start']


### PR DESCRIPTION
Autocomplete will fail it text is added to the console between the autocomplete request and the autocomplet reply, even if this text is added before the prompt. I would expect this to fail only if the prompt is changed. Therefore, instead of checking the absolute position, this checks the prompt buffer and the position in the prompt buffer.