### PR TITLE
Prevent completion strip if it refers to a file

### DIFF
--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -110,12 +110,7 @@ class CompletionWidget(QtGui.QListWidget):
         for item in items:
             list_item = QtGui.QListWidgetItem()
             list_item.setData(QtCore.Qt.UserRole, item)
-            # Check if the item could refer to a file. The replacing of '"'
-            # is needed for items on Windows
-            if os.path.isfile(os.path.abspath(item.replace("\"", ""))):
-                list_item.setText(item)
-            else:
-                list_item.setText(item.replace("\"", "").split('.')[-1])
+            list_item.setText(item.split('.')[-1])
             self.addItem(list_item)
         height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -110,7 +110,12 @@ class CompletionWidget(QtGui.QListWidget):
         for item in items:
             list_item = QtGui.QListWidgetItem()
             list_item.setData(QtCore.Qt.UserRole, item)
-            list_item.setText(item.split('.')[-1])
+            # Check if the item could refer to a file. The replacing of '"'
+            # is needed for items on Windows
+            if os.path.isfile(os.path.abspath(item.replace("\"", ""))):
+                list_item.setText(item)
+            else:
+                list_item.setText(item.replace("\"", "").split('.')[-1])
             self.addItem(list_item)
         height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -24,7 +24,6 @@ class CompletionWidget(QtGui.QListWidget):
 
         self._text_edit = text_edit
         self.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
         self.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
 
@@ -110,7 +109,12 @@ class CompletionWidget(QtGui.QListWidget):
         for item in items:
             list_item = QtGui.QListWidgetItem()
             list_item.setData(QtCore.Qt.UserRole, item)
-            list_item.setText(item.split('.')[-1])
+            # Check if the item could refer to a file. The replacing of '"'
+            # is needed for items on Windows
+            if os.path.isfile(os.path.abspath(item.replace("\"", ""))):
+                list_item.setText(item)
+            else:
+                list_item.setText(item.replace("\"", "").split('.')[-1])
             self.addItem(list_item)
         height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
@@ -119,7 +123,8 @@ class CompletionWidget(QtGui.QListWidget):
             point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
             point.setY(point.y() - height)
         w = (self.sizeHintForColumn(0) +
-             self.verticalScrollBar().sizeHint().width())
+             self.verticalScrollBar().sizeHint().width() +
+             2 * self.frameWidth())
         self.setGeometry(point.x(), point.y(), w, height)
 
         # Move cursor to start of the prefix to replace it

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -193,7 +193,8 @@ def test_debug(qtconsole, qtbot):
                    modifier=QtCore.Qt.ShiftModifier)
 
     qtbot.waitUntil(
-        lambda: control.toPlainText().strip().split()[-1] == "ipdb>")
+        lambda: control.toPlainText().strip().split()[-1] == "ipdb>",
+        timeout=SHELL_TIMEOUT)
 
     # We should be able to move the cursor while debugging
     qtbot.keyClicks(control, "abd")

--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -3,6 +3,7 @@ import sys
 
 import unittest
 
+from ipython_genutils.py3compat import PY3
 from jupyter_client.blocking.channels import Empty
 
 from qtconsole.manager import QtKernelManager
@@ -142,13 +143,20 @@ class Tests(unittest.TestCase):
         # Get close
         comm.close('close')
         msg = self._get_next_msg()
-        # For some reason ipykernel notifies me that it is closing,
-        # even though I closed the comm
-        assert msg['header']['msg_type'] == 'comm_close'
-        assert comm.comm_id == msg['content']['comm_id']
-        msg = self._get_next_msg()
-        assert msg['header']['msg_type'] == 'stream'
-        assert msg['content']['text'] == 'close\n'
+
+        # Recived message has a header and parent header. The parent header has
+        # the info about the close message type in Python 3
+        if PY3:
+            assert msg['parent_header']['msg_type'] == 'comm_close'
+            assert msg['msg_type'] == 'stream'
+            assert msg['content']['text'] == 'close\n'
+        else:
+            # For some reason ipykernel notifies me that it is closing,
+            # even though I closed the comm
+            assert msg['header']['msg_type'] == 'comm_close'
+            assert comm.comm_id == msg['content']['comm_id']
+            msg = self._get_next_msg()
+            assert msg['header']['msg_type'] == 'stream'
 
 if __name__ == "__main__":
     unittest.main()

--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -144,7 +144,7 @@ class Tests(unittest.TestCase):
         comm.close('close')
         msg = self._get_next_msg()
 
-        # Recived message has a header and parent header. The parent header has
+        # Received message has a header and parent header. The parent header has
         # the info about the close message type in Python 3
         if PY3:
             assert msg['parent_header']['msg_type'] == 'comm_close'


### PR DESCRIPTION
A preview:

![qc](https://user-images.githubusercontent.com/16781833/68984903-c22cb500-07e0-11ea-8208-58bc615261e5.gif)


Fixes spyder-ide/spyder#10692

Pinging @ccordoba12 just in case