### PR TITLE
Remove code to expand tabs to spaces

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -127,6 +127,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     confirm_restart = Bool(True, config=True,
         help="Whether to ask for user confirmation when restarting kernel")
 
+    expand_output_tabs = Bool(False, config=True,
+        help='Whether to expand tabs of outputs (change tabs for 8 spaces)')
+
     lexer_class = DottedObjectName(config=True,
         help="The pygments lexer class to use."
     )
@@ -681,7 +684,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # Most consoles treat tabs as being 8 space characters. Convert tabs
         # to spaces so that output looks as expected regardless of this
         # widget's tab width.
-        text = text.expandtabs(8)
+        if self.expand_output_tabs:
+            text = text.expandtabs(8)
         self._append_plain_text(text, before_prompt=True)
 
     def flush_clearoutput(self):

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -127,9 +127,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     confirm_restart = Bool(True, config=True,
         help="Whether to ask for user confirmation when restarting kernel")
 
-    expand_output_tabs = Bool(False, config=True,
-        help='Whether to expand tabs of outputs (change tabs for 8 spaces)')
-
     lexer_class = DottedObjectName(config=True,
         help="The pygments lexer class to use."
     )
@@ -681,11 +678,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
     def append_stream(self, text):
         """Appends text to the output stream."""
-        # Most consoles treat tabs as being 8 space characters. Convert tabs
-        # to spaces so that output looks as expected regardless of this
-        # widget's tab width.
-        if self.expand_output_tabs:
-            text = text.expandtabs(8)
         self._append_plain_text(text, before_prompt=True)
 
     def flush_clearoutput(self):

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -598,6 +598,16 @@ class MainWindow(QtGui.QMainWindow):
                     action.setChecked(True)
                     self.syntax_style_menu.setDefaultAction(action)
 
+        self.output_format_menu = self.view_menu.addMenu("&Output format")
+        expand_output_tabs_action = QtGui.QAction(
+            "&Expand output tabs to spaces",
+            self,
+            checkable=True,
+            checked=self.active_frontend.expand_output_tabs,
+            triggered=self.toggle_expand_output_tabs_active_frontend
+            )
+        self.output_format_menu.addAction(expand_output_tabs_action)
+
     def init_kernel_menu(self):
         self.kernel_menu = self.menuBar().addMenu("&Kernel")
         # Qt on OSX maps Ctrl to Cmd, and Meta to Ctrl
@@ -783,6 +793,11 @@ class MainWindow(QtGui.QMainWindow):
         widget = self.active_frontend
         widget.confirm_restart = not widget.confirm_restart
         self.confirm_restart_kernel_action.setChecked(widget.confirm_restart)
+
+    def toggle_expand_output_tabs_active_frontend(self):
+        widget = self.active_frontend
+        widget.expand_output_tabs = not widget.expand_output_tabs
+        self.expand_output_tabs.setChecked(widget.expand_output_tabs)
 
     def update_restart_checkbox(self):
         if self.active_frontend is None:

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -598,16 +598,6 @@ class MainWindow(QtGui.QMainWindow):
                     action.setChecked(True)
                     self.syntax_style_menu.setDefaultAction(action)
 
-        self.output_format_menu = self.view_menu.addMenu("&Output format")
-        expand_output_tabs_action = QtGui.QAction(
-            "&Expand output tabs to spaces",
-            self,
-            checkable=True,
-            checked=self.active_frontend.expand_output_tabs,
-            triggered=self.toggle_expand_output_tabs_active_frontend
-            )
-        self.output_format_menu.addAction(expand_output_tabs_action)
-
     def init_kernel_menu(self):
         self.kernel_menu = self.menuBar().addMenu("&Kernel")
         # Qt on OSX maps Ctrl to Cmd, and Meta to Ctrl
@@ -793,11 +783,6 @@ class MainWindow(QtGui.QMainWindow):
         widget = self.active_frontend
         widget.confirm_restart = not widget.confirm_restart
         self.confirm_restart_kernel_action.setChecked(widget.confirm_restart)
-
-    def toggle_expand_output_tabs_active_frontend(self):
-        widget = self.active_frontend
-        widget.expand_output_tabs = not widget.expand_output_tabs
-        self.expand_output_tabs.setChecked(widget.expand_output_tabs)
 
     def update_restart_checkbox(self):
         if self.active_frontend is None:


### PR DESCRIPTION
@ccordoba12 a preview:

![tabs](https://user-images.githubusercontent.com/16781833/70168477-f33d2e80-1696-11ea-8d6e-c4465ed01db8.gif)

Fixes #396 