### PR TITLE
Add missing import to svg module

### DIFF
--- a/qtconsole/svg.py
+++ b/qtconsole/svg.py
@@ -2,7 +2,7 @@
 """
 
 # System library imports.
-from qtpy import QtCore, QtGui, QtSvg
+from qtpy import QtCore, QtGui, QtSvg, QtWidgets
 
 # Our own imports
 from ipython_genutils.py3compat import unicode_type


### PR DESCRIPTION
This was detected by the Spyder test suite.