### PR TITLE
Make Qtconsole work on Python 3.8 and Windows

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -378,8 +378,39 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
             cfg[new_name].merge(cfg[old_name])
             return cfg
 
+    def _init_asyncio_patch(self):
+        """
+        Same workaround fix as https://github.com/ipython/ipykernel/pull/456
+
+        Set default asyncio policy to be compatible with tornado
+        Tornado 6 (at least) is not compatible with the default
+        asyncio implementation on Windows
+        Pick the older SelectorEventLoopPolicy on Windows
+        if the known-incompatible default policy is in use.
+        do this as early as possible to make it a low priority and overrideable
+        ref: https://github.com/tornadoweb/tornado/issues/2608
+        FIXME: if/when tornado supports the defaults in asyncio,
+               remove and bump tornado requirement for py38
+        """
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+            import asyncio
+            try:
+                from asyncio import (
+                    WindowsProactorEventLoopPolicy,
+                    WindowsSelectorEventLoopPolicy,
+                )
+            except ImportError:
+                pass
+                # not affected
+            else:
+                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                    # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                    # fallback to the pre-3.8 default of Selector
+                    asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
     @catch_config_error
     def initialize(self, argv=None):
+        self._init_asyncio_patch()
         self.init_qt_app()
         super(JupyterQtConsoleApp, self).initialize(argv)
         if self._dispatching:


### PR DESCRIPTION
As described in #405, the qtconsole is currently not working on windows. As a workaround, this PR sets the default asyncio policy on windows with python 3.8 when the app object is created.

For more details, see https://github.com/ipython/ipykernel/pull/480 and https://github.com/tornadoweb/tornado/issues/2608.

Fixes #405.