### PR TITLE
Set updated prompt as previous prompt object in JupyterWidget

### DIFF
--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -406,6 +406,10 @@ class JupyterWidget(IPythonWidget):
             # Update the prompt cursor
             self._prompt_cursor.setPosition(cursor.position() - 1)
 
+            # Store the updated prompt.
+            block = self._control.document().lastBlock()
+            length = len(self._prompt)
+            self._previous_prompt_obj = self._PromptBlock(block, length, new_prompt_number)
 
     def _show_interpreter_prompt_for_reply(self, msg):
         """ Reimplemented for IPython-style prompts.


### PR DESCRIPTION
`self._previous_prompt_obj` stores information about the current prompt's length. JupyterWidget's `self._show_interpreter_prompt` sets `self._previous_prompt_obj`. A call to `self._update_prompt` only updates the displayed text, not also updating `self._previous_prompt_obj`. 

This isn't an issue when all prompts are the same length, which is the case in IPython. But if you use prompts of different length, the next `Out []` line is shown on the same line, covered by the prompt. It's also moved to the right by an amount dependent on the length of the input.

<img width="165" alt="Screenshot 2020-03-18 at 23 17 43" src="https://user-images.githubusercontent.com/24586651/77016124-b4459700-696e-11ea-9e60-2c56fa50a337.png">

Why prompts of different length? I'm subclassing the class in a rewrite of Orange's Python Script widget https://github.com/biolab/orange3/pull/4402, where I call these private methods to show that a script (written in a separate code editor widget) is running. 

I know the methods are private, but they make a great library for building/extending your own console.

Let me know if you need a minimal code example.
