### PR TITLE
PR: Fix Python 2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.7
     - python: "3.6"
-    - python: "2.7"
+    - python: "2.7.17"
 
 install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
@ccordoba12 ~~at the end I removed the testing in Python 2.7 (no idea what is causing the memory segfault, the only difference I saw in the logs was the change from Python `2.7.17` to Python `2.7.18` and that the Qt version changed from `5.9.7` to `5.9.4`)~~ seems like using Python 2.7.17 prevents the tests segfault in Python 2