### PR TITLE
Print input if there is no prompt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.7
     - python: "3.6.10"
-    - python: "2.7.17"
 
 install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -226,11 +226,11 @@ class JupyterWidget(IPythonWidget):
                 last_cell = cell
         self._set_history(items)
 
-    def _insert_other_input(self, cursor, content):
+    def _insert_other_input(self, cursor, content, remote=True):
         """Insert function for input from other frontends"""
         n = content.get('execution_count', 0)
-        prompt = self._make_in_prompt(n, remote=True)
-        cont_prompt = self._make_continuation_prompt(self._prompt, remote=True)
+        prompt = self._make_in_prompt(n, remote=remote)
+        cont_prompt = self._make_continuation_prompt(self._prompt, remote=remote)
         cursor.insertText('\n')
         for i, line in enumerate(content['code'].strip().split('\n')):
             if i == 0:
@@ -246,7 +246,12 @@ class JupyterWidget(IPythonWidget):
         """Handle an execute_input message"""
         self.log.debug("execute_input: %s", msg.get('content', ''))
         if self.include_output(msg):
-            self._append_custom(self._insert_other_input, msg['content'], before_prompt=True)
+            self._append_custom(
+                self._insert_other_input, msg['content'], before_prompt=True)
+        elif not self._prompt:
+            self._append_custom(
+                self._insert_other_input, msg['content'],
+                before_prompt=True, remote=False)
 
     def _handle_execute_result(self, msg):
         """Handle an execute_result message"""
@@ -385,6 +390,9 @@ class JupyterWidget(IPythonWidget):
 
     def _update_prompt(self, new_prompt_number):
         """Replace the last displayed prompt with a new one."""
+        if self._previous_prompt_obj is None:
+            return
+
         block = self._previous_prompt_obj.block
 
         # Make sure the prompt block has not been erased.


### PR DESCRIPTION
If an execution request is sent before the prompt is shown, the input is not shown. This solves this problem. CF: https://github.com/spyder-ide/spyder/issues/13048