### PR TITLE
Replace qApp with QApplication.instance()

### DIFF
--- a/qtconsole/call_tip_widget.py
+++ b/qtconsole/call_tip_widget.py
@@ -157,9 +157,9 @@ class CallTipWidget(QtWidgets.QLabel):
         # Locate and show the widget. Place the tip below the current line
         # unless it would be off the screen.  In that case, decide the best
         # location based trying to minimize the  area that goes off-screen.
-        padding = 3 # Distance in pixels between cursor bounds and tip box.
+        padding = 3  # Distance in pixels between cursor bounds and tip box.
         cursor_rect = text_edit.cursorRect(cursor)
-        screen_rect = QtWidgets.qApp.desktop().screenGeometry(text_edit)
+        screen_rect = QtWidgets.QApplication.instance().desktop().screenGeometry(text_edit)
         point = text_edit.mapToGlobal(cursor_rect.bottomRight())
         point.setY(point.y() + padding)
         tip_height = self.size().height()
@@ -244,7 +244,7 @@ class CallTipWidget(QtWidgets.QLabel):
             # If Enter events always came after Leave events, we wouldn't need
             # this check. But on Mac OS, it sometimes happens the other way
             # around when the tooltip is created.
-            QtWidgets.qApp.topLevelAt(QtGui.QCursor.pos()) != self):
+            QtWidgets.QApplication.instance().topLevelAt(QtGui.QCursor.pos()) != self):
             self._hide_timer.start(300, self)
 
     def _format_tooltip(self, doc):

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -420,7 +420,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                             self._ctrl_down_remap[key],
                                             QtCore.Qt.NoModifier)
-                QtWidgets.qApp.sendEvent(obj, new_event)
+                QtWidgets.QApplication.instance().sendEvent(obj, new_event)
                 return True
 
             elif obj == self._control:
@@ -1330,13 +1330,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                                 QtCore.Qt.Key_Return,
                                                 QtCore.Qt.NoModifier)
-                    QtWidgets.qApp.sendEvent(self._control, new_event)
+                    QtWidgets.QApplication.instance().sendEvent(self._control, new_event)
                     intercepted = True
                 else:
                     new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                                 QtCore.Qt.Key_Delete,
                                                 QtCore.Qt.NoModifier)
-                    QtWidgets.qApp.sendEvent(self._control, new_event)
+                    QtWidgets.QApplication.instance().sendEvent(self._control, new_event)
                     intercepted = True
 
         #------ Alt modifier ---------------------------------------------------
@@ -1569,14 +1569,14 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                         QtCore.Qt.Key_PageDown,
                                         QtCore.Qt.NoModifier)
-            QtWidgets.qApp.sendEvent(self._page_control, new_event)
+            QtWidgets.QApplication.instance().sendEvent(self._page_control, new_event)
             return True
 
         elif key == QtCore.Qt.Key_Backspace:
             new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                         QtCore.Qt.Key_PageUp,
                                         QtCore.Qt.NoModifier)
-            QtWidgets.qApp.sendEvent(self._page_control, new_event)
+            QtWidgets.QApplication.instance().sendEvent(self._page_control, new_event)
             return True
 
         # vi/less -like key bindings
@@ -1584,7 +1584,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                         QtCore.Qt.Key_Down,
                                         QtCore.Qt.NoModifier)
-            QtWidgets.qApp.sendEvent(self._page_control, new_event)
+            QtWidgets.QApplication.instance().sendEvent(self._page_control, new_event)
             return True
 
         # vi/less -like key bindings
@@ -1592,7 +1592,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                         QtCore.Qt.Key_Up,
                                         QtCore.Qt.NoModifier)
-            QtWidgets.qApp.sendEvent(self._page_control, new_event)
+            QtWidgets.QApplication.instance().sendEvent(self._page_control, new_event)
             return True
 
         return False
@@ -2096,7 +2096,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                             cursor.StartOfLine, cursor.KeepAnchor)
 
                     elif act.action == 'beep':
-                        QtWidgets.qApp.beep()
+                        QtWidgets.QApplication.instance().beep()
 
                     elif act.action == 'backspace':
                         if not cursor.atBlockStart():


### PR DESCRIPTION
In newer versions of __PySide2__ the attribute _qApp_ of module _QtWidgets_ is removed.
This PR changes all the occurrences of _qApp_ with _QApplication.instance()_
As this attribute doesn't exist on newer versions of PySide2 it causes a crash on my application.
This doesn't affect previous versions of PySide2 as _qApp_ attribute is the same as _QApplication.instance()_, verified on PySide2 5.11.2.

![Crash](https://i.imgur.com/DrsiRQH.png)

Tested on __PySide2 5.15.0 LTS__.

