### PR TITLE
Use new Python 3 super syntax

### DIFF
--- a/qtconsole/bracket_matcher.py
+++ b/qtconsole/bracket_matcher.py
@@ -23,7 +23,7 @@ class BracketMatcher(QtCore.QObject):
             text edit widget.
         """
         assert isinstance(text_edit, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(BracketMatcher, self).__init__()
+        super().__init__()
 
         # The format to apply to matching brackets.
         self.format = QtGui.QTextCharFormat()

--- a/qtconsole/call_tip_widget.py
+++ b/qtconsole/call_tip_widget.py
@@ -19,7 +19,7 @@ class CallTipWidget(QtWidgets.QLabel):
             text edit widget.
         """
         assert isinstance(text_edit, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(CallTipWidget, self).__init__(None, QtCore.Qt.ToolTip)
+        super().__init__(None, QtCore.Qt.ToolTip)
 
         self._hide_timer = QtCore.QBasicTimer()
         self._text_edit = text_edit
@@ -62,7 +62,7 @@ class CallTipWidget(QtWidgets.QLabel):
             elif etype == QtCore.QEvent.Leave:
                 self._leave_event_hide()
 
-        return super(CallTipWidget, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     def timerEvent(self, event):
         """ Reimplemented to hide the widget when the hide timer fires.
@@ -78,13 +78,13 @@ class CallTipWidget(QtWidgets.QLabel):
     def enterEvent(self, event):
         """ Reimplemented to cancel the hide timer.
         """
-        super(CallTipWidget, self).enterEvent(event)
+        super().enterEvent(event)
         self._hide_timer.stop()
 
     def hideEvent(self, event):
         """ Reimplemented to disconnect signal handlers and event filter.
         """
-        super(CallTipWidget, self).hideEvent(event)
+        super().hideEvent(event)
         # This fixes issue jupyter/qtconsole#383
         try:
             self._text_edit.cursorPositionChanged.disconnect(
@@ -96,7 +96,7 @@ class CallTipWidget(QtWidgets.QLabel):
     def leaveEvent(self, event):
         """ Reimplemented to start the hide timer.
         """
-        super(CallTipWidget, self).leaveEvent(event)
+        super().leaveEvent(event)
         self._leave_event_hide()
 
     def paintEvent(self, event):
@@ -108,17 +108,17 @@ class CallTipWidget(QtWidgets.QLabel):
         painter.drawPrimitive(QtWidgets.QStyle.PE_PanelTipLabel, option)
         painter.end()
 
-        super(CallTipWidget, self).paintEvent(event)
+        super().paintEvent(event)
 
     def setFont(self, font):
         """ Reimplemented to allow use of this method as a slot.
         """
-        super(CallTipWidget, self).setFont(font)
+        super().setFont(font)
 
     def showEvent(self, event):
         """ Reimplemented to connect signal handlers and event filter.
         """
-        super(CallTipWidget, self).showEvent(event)
+        super().showEvent(event)
         self._text_edit.cursorPositionChanged.connect(
             self._cursor_position_changed)
         self._text_edit.installEventFilter(self)

--- a/qtconsole/comms.py
+++ b/qtconsole/comms.py
@@ -27,7 +27,7 @@ class CommManager(MetaQObjectHasTraits(
     """
 
     def __init__(self, kernel_client, *args, **kwargs):
-        super(CommManager, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.comms = {}
         self.targets = {}
         if kernel_client:
@@ -192,7 +192,7 @@ class Comm(MetaQObjectHasTraits(
         """
         Create a new comm. Must call open to use.
         """
-        super(Comm, self).__init__(target_name=target_name)
+        super().__init__(target_name=target_name)
         self.target_name = target_name
         self.kernel_client = kernel_client
         if comm_id is None:

--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -130,7 +130,7 @@ class CompletionHtml(QtWidgets.QWidget):
             text edit widget.
         """
         assert isinstance(console_widget._control, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(CompletionHtml, self).__init__()
+        super().__init__()
 
         self._text_edit = console_widget._control
         self._console_widget = console_widget
@@ -192,7 +192,7 @@ class CompletionHtml(QtWidgets.QWidget):
             elif etype == QtCore.QEvent.FocusOut:
                 self.cancel_completion()
 
-        return super(CompletionHtml, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     #--------------------------------------------------------------------------
     # 'CompletionHtml' interface

--- a/qtconsole/completion_plain.py
+++ b/qtconsole/completion_plain.py
@@ -19,7 +19,7 @@ class CompletionPlain(QtWidgets.QWidget):
             text edit widget.
         """
         assert isinstance(console_widget._control, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(CompletionPlain, self).__init__()
+        super().__init__()
 
         self._text_edit = console_widget._control
         self._console_widget = console_widget
@@ -36,7 +36,7 @@ class CompletionPlain(QtWidgets.QWidget):
             if etype in( QtCore.QEvent.KeyPress, QtCore.QEvent.FocusOut ):
                 self.cancel_completion()
 
-        return super(CompletionPlain, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     #--------------------------------------------------------------------------
     # 'CompletionPlain' interface

--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -20,7 +20,7 @@ class CompletionWidget(QtWidgets.QListWidget):
         """
         text_edit = console_widget._control
         assert isinstance(text_edit, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(CompletionWidget, self).__init__(parent=console_widget)
+        super().__init__(parent=console_widget)
 
         self._text_edit = text_edit
         self.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
@@ -58,7 +58,7 @@ class CompletionWidget(QtWidgets.QListWidget):
                 else:
                     self.cancel_completion()
 
-        return super(CompletionWidget, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     def keyPressEvent(self, event):
         key = event.key()
@@ -70,7 +70,7 @@ class CompletionWidget(QtWidgets.QListWidget):
         elif key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
                      QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown,
                      QtCore.Qt.Key_Home, QtCore.Qt.Key_End):
-            return super(CompletionWidget, self).keyPressEvent(event)
+            return super().keyPressEvent(event)
         else:
             QtWidgets.QApplication.sendEvent(self._text_edit, event)
 
@@ -81,7 +81,7 @@ class CompletionWidget(QtWidgets.QListWidget):
     def hideEvent(self, event):
         """ Reimplemented to disconnect signal handlers and event filter.
         """
-        super(CompletionWidget, self).hideEvent(event)
+        super().hideEvent(event)
         try:
             self._text_edit.cursorPositionChanged.disconnect(self._update_current)
         except TypeError:
@@ -91,7 +91,7 @@ class CompletionWidget(QtWidgets.QListWidget):
     def showEvent(self, event):
         """ Reimplemented to connect signal handlers and event filter.
         """
-        super(CompletionWidget, self).showEvent(event)
+        super().showEvent(event)
         self._text_edit.cursorPositionChanged.connect(self._update_current)
         self.installEventFilter(self)
 

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -218,7 +218,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         parent : QWidget, optional [default None]
             The parent for this widget.
         """
-        super(ConsoleWidget, self).__init__(**kw)
+        super().__init__(**kw)
         if parent:
             self.setParent(parent)
 
@@ -467,7 +467,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             anchor = self._control.anchorAt(event.pos())
             QtWidgets.QToolTip.showText(event.globalPos(), anchor)
 
-        return super(ConsoleWidget, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     #---------------------------------------------------------------------------
     # 'QWidget' interface

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -27,7 +27,7 @@ class FrontendHighlighter(PygmentsHighlighter):
     """
 
     def __init__(self, frontend, lexer=None):
-        super(FrontendHighlighter, self).__init__(frontend._control.document(), lexer=lexer)
+        super().__init__(frontend._control.document(), lexer=lexer)
         self._current_offset = 0
         self._frontend = frontend
         self.highlighting_on = False
@@ -78,21 +78,21 @@ class FrontendHighlighter(PygmentsHighlighter):
         diff = len(string) - len(without_prompt)
         if diff > 0:
             self._current_offset = diff
-            super(FrontendHighlighter, self).highlightBlock(without_prompt)
+            super().highlightBlock(without_prompt)
 
     def rehighlightBlock(self, block):
         """ Reimplemented to temporarily enable highlighting if disabled.
         """
         old = self.highlighting_on
         self.highlighting_on = True
-        super(FrontendHighlighter, self).rehighlightBlock(block)
+        super().rehighlightBlock(block)
         self.highlighting_on = old
 
     def setFormat(self, start, count, format):
         """ Reimplemented to highlight selectively.
         """
         start += self._current_offset
-        super(FrontendHighlighter, self).setFormat(start, count, format)
+        super().setFormat(start, count, format)
 
 
 class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
@@ -167,7 +167,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     # -------------------------------------------------------------------------
 
     def __init__(self, local_kernel=_local_kernel, *args, **kw):
-        super(FrontendWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         # FrontendWidget protected variables.
         self._bracket_matcher = BracketMatcher(self._control)
         self._call_tip_widget = CallTipWidget(self._control)
@@ -290,7 +290,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _context_menu_make(self, pos):
         """ Reimplemented to add an action for raw copy.
         """
-        menu = super(FrontendWidget, self)._context_menu_make(pos)
+        menu = super()._context_menu_make(pos)
         for before_action in menu.actions():
             if before_action.shortcut().matches(QtGui.QKeySequence.Paste) == \
                     QtGui.QKeySequence.ExactMatch:
@@ -336,7 +336,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                         cursor.removeSelectedText()
                         return True
 
-        return super(FrontendWidget, self)._event_filter_console_keypress(event)
+        return super()._event_filter_console_keypress(event)
 
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface

--- a/qtconsole/history_console_widget.py
+++ b/qtconsole/history_console_widget.py
@@ -25,7 +25,7 @@ class HistoryConsoleWidget(ConsoleWidget):
     #---------------------------------------------------------------------------
 
     def __init__(self, *args, **kw):
-        super(HistoryConsoleWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         # HistoryConsoleWidget protected variables.
         self._history = []
@@ -40,7 +40,7 @@ class HistoryConsoleWidget(ConsoleWidget):
         """ Reimplemented to the store history. """
         history = self.input_buffer if source is None else source
 
-        super(HistoryConsoleWidget, self).do_execute(source, complete, indent)
+        super().do_execute(source, complete, indent)
 
         if complete:
             # Save the command unless it was an empty string or was identical

--- a/qtconsole/inprocess.py
+++ b/qtconsole/inprocess.py
@@ -27,13 +27,13 @@ class QtInProcessChannel(SuperQObject, InProcessChannel):
     def start(self):
         """ Reimplemented to emit signal.
         """
-        super(QtInProcessChannel, self).start()
+        super().start()
         self.started.emit()
 
     def stop(self):
         """ Reimplemented to emit signal.
         """
-        super(QtInProcessChannel, self).stop()
+        super().stop()
         self.stopped.emit()
 
     def call_handlers_later(self, *args, **kwds):
@@ -53,7 +53,7 @@ class QtInProcessChannel(SuperQObject, InProcessChannel):
     def flush(self, timeout=1.0):
         """ Reimplemented to ensure that signals are dispatched immediately.
         """
-        super(QtInProcessChannel, self).flush()
+        super().flush()
         self.process_events()
 
 

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -115,7 +115,7 @@ class JupyterWidget(IPythonWidget):
     #---------------------------------------------------------------------------
 
     def __init__(self, *args, **kw):
-        super(JupyterWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         # JupyterWidget protected variables.
         self._payload_handlers = {
@@ -191,7 +191,7 @@ class JupyterWidget(IPythonWidget):
                 self._show_interpreter_prompt(number)
             self._request_info['execute'].pop(msg_id)
         else:
-            super(JupyterWidget, self)._handle_execute_reply(msg)
+            super()._handle_execute_reply(msg)
 
     def _handle_history_reply(self, msg):
         """ Handle history tail replies, which are only supported
@@ -317,7 +317,7 @@ class JupyterWidget(IPythonWidget):
         if self._starting:
             # finish handling started channels
             self._starting = False
-            super(JupyterWidget, self)._started_channels()
+            super()._started_channels()
 
     def _started_channels(self):
         """Make a history request"""
@@ -612,4 +612,4 @@ class IPythonWidget(JupyterWidget):
     def __init__(self, *a, **kw):
         warn("IPythonWidget is deprecated; use JupyterWidget",
              DeprecationWarning)
-        super(IPythonWidget, self).__init__(*a, **kw)
+        super().__init__(*a, **kw)

--- a/qtconsole/kernel_mixins.py
+++ b/qtconsole/kernel_mixins.py
@@ -37,20 +37,20 @@ class QtKernelClientMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObje
     #---------------------------------------------------------------------------
 
     def __init__(self, *args, **kwargs):
-        super(QtKernelClientMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.comm_manager = None
     #------ Channel management -------------------------------------------------
 
     def start_channels(self, *args, **kw):
         """ Reimplemented to emit signal.
         """
-        super(QtKernelClientMixin, self).start_channels(*args, **kw)
+        super().start_channels(*args, **kw)
         self.started_channels.emit()
         self.comm_manager = CommManager(parent=self, kernel_client=self)
 
     def stop_channels(self):
         """ Reimplemented to emit signal.
         """
-        super(QtKernelClientMixin, self).stop_channels()
+        super().stop_channels()
         self.stopped_channels.emit()
         self.comm_manager = None

--- a/qtconsole/kill_ring.py
+++ b/qtconsole/kill_ring.py
@@ -63,7 +63,7 @@ class QtKillRing(QtCore.QObject):
         """ Create a kill ring attached to the specified Qt text edit.
         """
         assert isinstance(text_edit, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
-        super(QtKillRing, self).__init__()
+        super().__init__()
 
         self._ring = KillRing()
         self._prev_yank = None

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -53,7 +53,7 @@ class MainWindow(QtWidgets.QMainWindow):
             JupyterWidget instance, attached to the same kernel.
         """
 
-        super(MainWindow, self).__init__()
+        super().__init__()
         self._kernel_counter = 0
         self._external_kernel_counter = 0
         self._app = app

--- a/qtconsole/manager.py
+++ b/qtconsole/manager.py
@@ -24,7 +24,7 @@ class QtKernelRestarter(KernelRestarter, QtKernelRestarterMixin):
         self._timer.stop()
 
     def poll(self):
-        super(QtKernelRestarter, self).poll()
+        super().poll()
 
 
 class QtKernelManager(KernelManager, QtKernelManagerMixin):

--- a/qtconsole/pygments_highlighter.py
+++ b/qtconsole/pygments_highlighter.py
@@ -104,7 +104,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     #---------------------------------------------------------------------------
 
     def __init__(self, parent, lexer=None):
-        super(PygmentsHighlighter, self).__init__(parent)
+        super().__init__(parent)
 
         self._document = self.document()
         self._formatter = HtmlFormatter(nowrap=True)

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -174,7 +174,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     widget_factory = Any(RichJupyterWidget)
 
     def parse_command_line(self, argv=None):
-        super(JupyterQtConsoleApp, self).parse_command_line(argv)
+        super().parse_command_line(argv)
         self.build_kernel_argv(self.extra_args)
 
 
@@ -412,7 +412,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         self._init_asyncio_patch()
         self.init_qt_app()
-        super(JupyterQtConsoleApp, self).initialize(argv)
+        super().initialize(argv)
         if self._dispatching:
             return
         # handle deprecated renames
@@ -429,7 +429,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         self.init_signal()
 
     def start(self):
-        super(JupyterQtConsoleApp, self).start()
+        super().start()
 
         # draw the window
         if self.maximize:
@@ -446,7 +446,7 @@ class IPythonQtConsoleApp(JupyterQtConsoleApp):
     def __init__(self, *a, **kw):
         warn("IPythonQtConsoleApp is deprecated; use JupyterQtConsoleApp",
              DeprecationWarning)
-        super(IPythonQtConsoleApp, self).__init__(*a, **kw)
+        super().__init__(*a, **kw)
 
 
 # -----------------------------------------------------------------------------

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -50,7 +50,7 @@ class RichJupyterWidget(RichIPythonWidget):
         """ Create a RichJupyterWidget.
         """
         kw['kind'] = 'rich'
-        super(RichJupyterWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         # Configure the ConsoleWidget HTML exporter for our formats.
         self._html_exporter.image_tag = self._get_image_tag
@@ -75,7 +75,7 @@ class RichJupyterWidget(RichIPythonWidget):
         to the export running.
         """
         self._svg_warning_displayed = False
-        super(RichJupyterWidget, self).export_html()
+        super().export_html()
 
 
     #---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ class RichJupyterWidget(RichIPythonWidget):
                 menu.addAction('Save SVG As...',
                                lambda: save_svg(svg, self._control))
         else:
-            menu = super(RichJupyterWidget, self)._context_menu_make(pos)
+            menu = super()._context_menu_make(pos)
         return menu
 
     #---------------------------------------------------------------------------
@@ -146,11 +146,11 @@ class RichJupyterWidget(RichIPythonWidget):
                 try:
                     self._append_latex(data['text/latex'], True)
                 except LatexError:
-                    return super(RichJupyterWidget, self)._handle_display_data(msg)
+                    return super()._handle_display_data(msg)
                 self._append_html(self.output_sep2, True)
             else:
                 # Default back to the plain text representation.
-                return super(RichJupyterWidget, self)._handle_execute_result(msg)
+                return super()._handle_execute_result(msg)
 
     def _handle_display_data(self, msg):
         """Overridden to handle rich data types, like SVG."""
@@ -177,10 +177,10 @@ class RichJupyterWidget(RichIPythonWidget):
                 try:
                     self._append_latex(data['text/latex'], True)
                 except LatexError:
-                    return super(RichJupyterWidget, self)._handle_display_data(msg)
+                    return super()._handle_display_data(msg)
             else:
                 # Default back to the plain text representation.
-                return super(RichJupyterWidget, self)._handle_display_data(msg)
+                return super()._handle_display_data(msg)
 
     #---------------------------------------------------------------------------
     # 'RichJupyterWidget' protected interface
@@ -415,4 +415,4 @@ class RichIPythonWidget(RichJupyterWidget):
     def __init__(self, *a, **kw):
         warn("RichIPythonWidget is deprecated, use RichJupyterWidget",
              DeprecationWarning)
-        super(RichIPythonWidget, self).__init__(*a, **kw)
+        super().__init__(*a, **kw)


### PR DESCRIPTION
This PR updates the use of `super` i.e. it replaces `super(ClassName, self).` with `super()` which is the recommended way on Python 3.