### PR TITLE
Remove/replace more py2 compat code

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -12,7 +12,6 @@ import re
 from qtpy import QtGui
 
 # Local imports
-from ipython_genutils.py3compat import string_types
 from qtconsole.styles import dark_style
 
 #-----------------------------------------------------------------------------
@@ -335,7 +334,7 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
         else:
             return None
 
-        if isinstance(constructor, string_types):
+        if isinstance(constructor, str):
             # If this is an X11 color name, we just hope there is a close SVG
             # color name. We could use QColor's static method
             # 'setAllowX11ColorNames()', but this is global and only available

--- a/qtconsole/comms.py
+++ b/qtconsole/comms.py
@@ -12,7 +12,6 @@ import logging
 from traitlets.config import LoggingConfigurable
 
 from ipython_genutils.importstring import import_item
-from ipython_genutils.py3compat import string_types
 
 import uuid
 
@@ -76,7 +75,7 @@ class CommManager(MetaQObjectHasTraits(
 
         f can be a Python callable or an import string for one.
         """
-        if isinstance(f, string_types):
+        if isinstance(f, str):
             f = import_item(f)
 
         self.targets[target_name] = f

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -11,7 +11,6 @@ import uuid
 import re
 
 from qtpy import QtCore, QtGui, QtWidgets
-from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
 
 from qtconsole.base_frontend_mixin import BaseFrontendMixin
@@ -134,10 +133,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self.lexer = lexer_class()
 
     def _lexer_class_default(self):
-        if py3compat.PY3:
-            return 'pygments.lexers.Python3Lexer'
-        else:
-            return 'pygments.lexers.PythonLexer'
+        return 'pygments.lexers.Python3Lexer'
 
     lexer = Any()
     def _lexer_default(self):

--- a/qtconsole/history_console_widget.py
+++ b/qtconsole/history_console_widget.py
@@ -3,7 +3,6 @@
 
 from qtpy import QtGui
 
-from ipython_genutils.py3compat import unicode_type
 from traitlets import Bool
 from .console_widget import ConsoleWidget
 
@@ -242,7 +241,7 @@ class HistoryConsoleWidget(ConsoleWidget):
         if index in self._history_edits:
             return self._history_edits[index]
         elif index == len(self._history):
-            return unicode_type()
+            return str()
         return self._history[index]
 
     def _set_history(self, history):

--- a/qtconsole/pygments_highlighter.py
+++ b/qtconsole/pygments_highlighter.py
@@ -4,10 +4,9 @@
 from qtpy import QtGui
 from qtconsole.qstringhelpers import qstring_length
 
-from ipython_genutils.py3compat import PY3, string_types
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexer import RegexLexer, _TokenType, Text, Error
-from pygments.lexers import PythonLexer, Python3Lexer
+from pygments.lexers import Python3Lexer
 from pygments.styles import get_style_by_name
 
 
@@ -112,10 +111,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
         if lexer is not None:
             self._lexer = lexer
         else:
-            if PY3:
-                self._lexer = Python3Lexer()
-            else:
-                self._lexer = PythonLexer()
+            self._lexer = Python3Lexer()
 
     def highlightBlock(self, string):
         """ Highlight a block of text.
@@ -147,7 +143,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def set_style(self, style):
         """ Sets the style to the specified Pygments style.
         """
-        if isinstance(style, string_types):
+        if isinstance(style, str):
             style = get_style_by_name(style)
         self._style = style
         self._clear_caches()

--- a/qtconsole/svg.py
+++ b/qtconsole/svg.py
@@ -4,8 +4,6 @@
 # System library imports.
 from qtpy import QtCore, QtGui, QtSvg, QtWidgets
 
-# Our own imports
-from ipython_genutils.py3compat import unicode_type
 
 def save_svg(string, parent=None):
     """ Prompts the user to save an SVG document to disk.
@@ -23,7 +21,7 @@ def save_svg(string, parent=None):
     The name of the file to which the document was saved, or None if the save
     was cancelled.
     """
-    if isinstance(string, unicode_type):
+    if isinstance(string, str):
         string = string.encode('utf-8')
 
     dialog = QtWidgets.QFileDialog(parent, 'Save SVG Document')
@@ -48,7 +46,7 @@ def svg_to_clipboard(string):
     string : basestring
         A Python string containing a SVG document.
     """
-    if isinstance(string, unicode_type):
+    if isinstance(string, str):
         string = string.encode('utf-8')
 
     mime_data = QtCore.QMimeData()
@@ -76,7 +74,7 @@ def svg_to_image(string, size=None):
     -------
     A QImage of format QImage.Format_ARGB32.
     """
-    if isinstance(string, unicode_type):
+    if isinstance(string, str):
         string = string.encode('utf-8')
 
     renderer = QtSvg.QSvgRenderer(QtCore.QByteArray(string))

--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -3,7 +3,6 @@ import sys
 
 import unittest
 
-from ipython_genutils.py3compat import PY3
 from jupyter_client.blocking.channels import Empty
 
 from qtconsole.manager import QtKernelManager
@@ -146,17 +145,9 @@ class Tests(unittest.TestCase):
 
         # Received message has a header and parent header. The parent header has
         # the info about the close message type in Python 3
-        if PY3:
-            assert msg['parent_header']['msg_type'] == 'comm_close'
-            assert msg['msg_type'] == 'stream'
-            assert msg['content']['text'] == 'close\n'
-        else:
-            # For some reason ipykernel notifies me that it is closing,
-            # even though I closed the comm
-            assert msg['header']['msg_type'] == 'comm_close'
-            assert comm.comm_id == msg['content']['comm_id']
-            msg = self._get_next_msg()
-            assert msg['header']['msg_type'] == 'stream'
+        assert msg['parent_header']['msg_type'] == 'comm_close'
+        assert msg['msg_type'] == 'stream'
+        assert msg['content']['text'] == 'close\n'
 
 if __name__ == "__main__":
     unittest.main()

--- a/qtconsole/util.py
+++ b/qtconsole/util.py
@@ -5,7 +5,6 @@ import inspect
 
 from qtpy import QtCore, QtGui
 
-from ipython_genutils.py3compat import iteritems
 from traitlets import HasTraits, TraitType
 
 #-----------------------------------------------------------------------------
@@ -25,7 +24,7 @@ class MetaQObjectHasTraits(MetaQObject, MetaHasTraits):
     def __new__(mcls, name, bases, classdict):
         # FIXME: this duplicates the code from MetaHasTraits.
         # I don't think a super() call will help me here.
-        for k,v in iteritems(classdict):
+        for k,v in iter(classdict.items()):
             if isinstance(v, TraitType):
                 v.name = k
             elif inspect.isclass(v):

--- a/qtconsole/util.py
+++ b/qtconsole/util.py
@@ -5,7 +5,6 @@ import inspect
 
 from qtpy import QtCore, QtGui
 
-from ipython_genutils.py3compat import iteritems
 from traitlets import HasTraits, TraitType
 
 #-----------------------------------------------------------------------------
@@ -25,7 +24,7 @@ class MetaQObjectHasTraits(MetaQObject, MetaHasTraits):
     def __new__(mcls, name, bases, classdict):
         # FIXME: this duplicates the code from MetaHasTraits.
         # I don't think a super() call will help me here.
-        for k,v in iteritems(classdict):
+        for k,v in classdict.items():
             if isinstance(v, TraitType):
                 v.name = k
             elif inspect.isclass(v):

--- a/qtconsole/util.py
+++ b/qtconsole/util.py
@@ -5,6 +5,7 @@ import inspect
 
 from qtpy import QtCore, QtGui
 
+from ipython_genutils.py3compat import iteritems
 from traitlets import HasTraits, TraitType
 
 #-----------------------------------------------------------------------------
@@ -24,7 +25,7 @@ class MetaQObjectHasTraits(MetaQObject, MetaHasTraits):
     def __new__(mcls, name, bases, classdict):
         # FIXME: this duplicates the code from MetaHasTraits.
         # I don't think a super() call will help me here.
-        for k,v in classdict.items():
+        for k,v in iteritems(classdict):
             if isinstance(v, TraitType):
                 v.name = k
             elif inspect.isclass(v):


### PR DESCRIPTION
- string_types on python 3 is just str
- unicode_type on python 3 is just str
- iteritems on python 3 is just dict.items()
- remove 2/3 conditionals