### PR TITLE
Remove u-string prefixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -251,8 +251,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'JupyterQtConsole.tex', u'Jupyter Qt Console Documentation',
-   u'Jupyter Development Team', 'manual'),
+  (master_doc, 'JupyterQtConsole.tex', 'Jupyter Qt Console Documentation',
+   'Jupyter Development Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -281,7 +281,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'jupyterqtconsole', u'Jupyter Qt Console Documentation',
+    (master_doc, 'jupyterqtconsole', 'Jupyter Qt Console Documentation',
      [author], 1)
 ]
 
@@ -295,7 +295,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'JupyterQtConsole', u'Jupyter Qt Console Documentation',
+  (master_doc, 'JupyterQtConsole', 'Jupyter Qt Console Documentation',
    author, 'JupyterQtConsole', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/qtconsole/completion_html.py
+++ b/qtconsole/completion_html.py
@@ -16,30 +16,30 @@ def html_tableify(item_matrix, select=None, header=None , footer=None) :
     if not item_matrix :
         return ''
     html_cols = []
-    tds = lambda text : u'<td>'+text+u'  </td>'
-    trs = lambda text : u'<tr>'+text+u'</tr>'
+    tds = lambda text : '<td>'+text+'  </td>'
+    trs = lambda text : '<tr>'+text+'</tr>'
     tds_items = [list(map(tds, row)) for row in item_matrix]
     if select :
         row, col = select
-        tds_items[row][col] = u'<td class="inverted">'\
+        tds_items[row][col] = '<td class="inverted">'\
                 +item_matrix[row][col]\
-                +u'  </td>'
+                +'  </td>'
     #select the right item
-    html_cols = map(trs, (u''.join(row) for row in tds_items))
+    html_cols = map(trs, (''.join(row) for row in tds_items))
     head = ''
     foot = ''
     if header :
-        head = (u'<tr>'\
-            +''.join((u'<td>'+header+u'</td>')*len(item_matrix[0]))\
+        head = ('<tr>'\
+            +''.join(('<td>'+header+'</td>')*len(item_matrix[0]))\
             +'</tr>')
 
     if footer :
-        foot = (u'<tr>'\
-            +''.join((u'<td>'+footer+u'</td>')*len(item_matrix[0]))\
+        foot = ('<tr>'\
+            +''.join(('<td>'+footer+'</td>')*len(item_matrix[0]))\
             +'</tr>')
-    html = (u'<table class="completion" style="white-space:pre"'
+    html = ('<table class="completion" style="white-space:pre"'
             'cellspacing=0>' +
-            head + (u''.join(html_cols)) + foot + u'</table>')
+            head + (''.join(html_cols)) + foot + '</table>')
     return html
 
 class SlidingInterval(object):

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -578,11 +578,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
     def _handle_is_complete_reply(self, msg):
         if msg['parent_header'].get('msg_id', 0) != self._is_complete_msg_id:
             return
-        status = msg['content'].get('status', u'complete')
-        indent = msg['content'].get('indent', u'')
+        status = msg['content'].get('status', 'complete')
+        indent = msg['content'].get('indent', '')
         self._trigger_is_complete_callback(status != 'incomplete', indent)
 
-    def _trigger_is_complete_callback(self, complete=False, indent=u''):
+    def _trigger_is_complete_callback(self, complete=False, indent=''):
         if self._is_complete_msg_id is not None:
             self._is_complete_msg_id = None
             self._is_complete_callback(complete, indent)
@@ -1945,7 +1945,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
     def _indent(self, dedent=True):
         """ Indent/Dedent current line or current text selection.
         """
-        num_newlines = self._get_cursor().selectedText().count(u"\u2029")
+        num_newlines = self._get_cursor().selectedText().count("\u2029")
         save_cur = self._get_cursor()
         cur = self._get_cursor()
 

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -218,7 +218,7 @@ class JupyterWidget(IPythonWidget):
         history_items = content['history']
         self.log.debug("Received history reply with %i entries", len(history_items))
         items = []
-        last_cell = u""
+        last_cell = ""
         for _, _, cell in history_items:
             cell = cell.rstrip()
             if cell != last_cell:
@@ -292,7 +292,7 @@ class JupyterWidget(IPythonWidget):
                 text = data['text/plain']
                 self._append_plain_text(text, True)
             # This newline seems to be needed for text and html output.
-            self._append_plain_text(u'\n', True)
+            self._append_plain_text('\n', True)
 
     def _handle_kernel_info_reply(self, rep):
         """Handle kernel info replies."""

--- a/qtconsole/pygments_highlighter.py
+++ b/qtconsole/pygments_highlighter.py
@@ -65,7 +65,7 @@ def get_tokens_unprocessed(self, text, stack=('root',)):
                     pos += 1
                     statestack = ['root']
                     statetokens = tokendefs['root']
-                    yield pos, Text, u'\n'
+                    yield pos, Text, '\n'
                     continue
                 yield pos, Error, text[pos]
                 pos += 1
@@ -192,7 +192,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def _get_format_from_document(self, token, document):
         """ Returns a QTextCharFormat for token by
         """
-        code, html = next(self._formatter._format_lines([(token, u'dummy')]))
+        code, html = next(self._formatter._format_lines([(token, 'dummy')]))
         self._document.setHtml(html)
         return QtGui.QTextCursor(self._document).charFormat()
 

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -40,8 +40,8 @@ if os.name == 'nt':
         try:
             import ctypes, traceback
             MB_ICONERROR = 0x00000010
-            title = u'Error starting QtConsole'
-            msg = u''.join(traceback.format_exception(exctype, value, tb))
+            title = 'Error starting QtConsole'
+            msg = ''.join(traceback.format_exception(exctype, value, tb))
             ctypes.windll.user32.MessageBoxW(0, msg, title, MB_ICONERROR)
         finally:
             # Also call the old exception hook to let it do

--- a/qtconsole/rich_text.py
+++ b/qtconsole/rich_text.py
@@ -177,7 +177,7 @@ def export_xhtml(html, filename, image_tag=None):
         # valid XML.
         offset = html.find("<html>")
         assert offset > -1, 'Invalid HTML string: no <html> tag.'
-        html = (u'<html xmlns="http://www.w3.org/1999/xhtml">\n'+
+        html = ('<html xmlns="http://www.w3.org/1999/xhtml">\n'+
                 html[offset+6:])
 
         html = fix_html(html)
@@ -206,7 +206,7 @@ def default_image_tag(match, path = None, format = "png"):
     format : "png"|"svg", optional [default "png"]
         Format for returned or referenced images.
     """
-    return u''
+    return ''
 
 
 def fix_html(html):

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -242,9 +242,9 @@ class TestConsoleWidget(unittest.TestCase):
                        'foo\b\nbar\n',
                        'foo\b\nbar\r\n',
                        'abc\rxyz\b\b=']
-        expected_outputs = [u'x=z\u2029',
-                            u'foo\u2029bar\u2029',
-                            u'foo\u2029bar\u2029',
+        expected_outputs = ['x=z\u2029',
+                            'foo\u2029bar\u2029',
+                            'foo\u2029bar\u2029',
                             'x=z']
         for i, text in enumerate(test_inputs):
             w._insert_plain_text(cursor, text)
@@ -265,14 +265,14 @@ class TestConsoleWidget(unittest.TestCase):
         w._insert_html(cursor, '<a href="http://python.org">written in</a>')
         obj = w._control
         tip = QtWidgets.QToolTip
-        self.assertEqual(tip.text(), u'')
+        self.assertEqual(tip.text(), '')
 
         # should be somewhere else
         elsewhereEvent = QMouseEvent(MouseMove, QtCore.QPoint(50,50),
                                      noButton, noButtons, noModifiers)
         w.eventFilter(obj, elsewhereEvent)
         self.assertEqual(tip.isVisible(), False)
-        self.assertEqual(tip.text(), u'')
+        self.assertEqual(tip.text(), '')
         # should be over text
         overTextEvent = QMouseEvent(MouseMove, QtCore.QPoint(1,5),
                                     noButton, noButtons, noModifiers)
@@ -549,7 +549,7 @@ class TestConsoleWidget(unittest.TestCase):
         w._handle_is_complete_reply(
             dict(parent_header=dict(msg_id=msg_id),
                  content=dict(status="incomplete", indent="!!!")))
-        self.assert_text_equal(cursor, u"thing\u2029> !!!")
+        self.assert_text_equal(cursor, "thing\u2029> !!!")
         self.assertEqual(calls, [])
 
         # test complete statement (_execute called)
@@ -562,16 +562,16 @@ class TestConsoleWidget(unittest.TestCase):
                  content=dict(status="complete", indent="###")))
         self.assertEqual(calls, [("else", False)])
         calls = []
-        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029")
+        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029")
 
         # test missing answer from is_complete
         msg_id = object()
         w.execute("done", interactive=True)
         self.assertEqual(calls, ["done"])
         calls = []
-        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029")
+        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029")
         w._trigger_is_complete_callback()
-        self.assert_text_equal(cursor, u"thing\u2029> !!!else\u2029\u2029> ")
+        self.assert_text_equal(cursor, "thing\u2029> !!!else\u2029\u2029> ")
 
         # assert that late answer isn't destroying anything
         w._handle_is_complete_reply(

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -58,24 +58,24 @@ class TestJupyterWidget(unittest.TestCase):
 
         self.assertEqual(document.blockCount(), 6)
         self.assertEqual(document.toPlainText(), (
-            u'Header\n'
-            u'\n'
-            u'[other] In [1]: a = 1 + 1\n'
-            u'           ...: b = range(10)\n'
-            u'\n'
-            u'In [2]: '
+            'Header\n'
+            '\n'
+            '[other] In [1]: a = 1 + 1\n'
+            '           ...: b = range(10)\n'
+            '\n'
+            'In [2]: '
         ))
 
         # Check proper syntax highlighting
         self.assertEqual(document.toHtml(), (
-            u'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
-            u'<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
-            u'p, li { white-space: pre-wrap; }\n'
-            u'</style></head><body style=" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;">\n'
-            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
-            u'<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:600; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
-            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
-            u'<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-            u'<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
+            '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
+            '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
+            'p, li { white-space: pre-wrap; }\n'
+            '</style></head><body style=" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;">\n'
+            '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
+            '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+            '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:600; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
+            '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
+            '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+            '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
         ))


### PR DESCRIPTION
The u-string prefixes are redundant and unnecessary on python 3. Note that this was split into a standalone PR given the volume of changes.