### PR TITLE
Add python_requires for Python 3.6+ compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_args = dict(
     license                       = 'BSD',
     platforms                     = "Linux, Mac OS X, Windows",
     keywords                      = ['Interactive', 'Interpreter', 'Shell'],
+    python_requires               = '>= 3.6',
     install_requires = [
         'traitlets',
         'ipython_genutils',


### PR DESCRIPTION
This change adds a python_requires directive, which prevents installing on unsupported Python versions. This is intended to fix #455 (And its duplicate #456), once a new release has been cut, and the bad release pulled.

Fixes #455.