### PR TITLE
PR: Remove partial prompt on copy

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -215,6 +215,19 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         elif self._control.hasFocus():
             text = self._control.textCursor().selection().toPlainText()
             if text:
+                # Adjust the cursor to not take partial prompts
+                cursor = self._control.textCursor()
+                start_pos = cursor.selectionStart()
+                cursor.setPosition(start_pos)
+                if (cursor.blockNumber() >=
+                        self._get_prompt_cursor().blockNumber()):
+                    # Only remove partial prompt if in edit area
+                    line_prompt_pos = (
+                        cursor.block().position()
+                        + len(self._continuation_prompt))
+                    if start_pos < line_prompt_pos:
+                        text = text[(line_prompt_pos - start_pos):]
+
                 # Remove prompts.
                 lines = text.splitlines()
                 lines = map(self._highlighter.transform_classic_prompt, lines)

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -243,7 +243,15 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                 if len(remaining_lines) > 0 and remaining_lines[-1]:
                     cursor = self._control.textCursor()
                     cursor.setPosition(cursor.selectionEnd())
-                    last_line_full = cursor.block().text()
+                    block = cursor.block()
+                    start_pos = block.position()
+                    length = block.length()
+                    cursor.setPosition(start_pos)
+                    cursor.setPosition(start_pos + length,
+                                       QtGui.QTextCursor.KeepAnchor)
+                    last_line_full = cursor.selection().toPlainText()
+                    if len(last_line_full) > 0 and last_line_full[-1] == "\n":
+                        last_line_full = last_line_full[:-1]
                     prompt_len = (
                         len(last_line_full)
                         - len(remove_prompts(last_line_full)))

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -237,7 +237,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
                 # Remove not selected part
                 if prompt_len < len(preceding_text):
-                    first_line = first_line[len(preceding_text)-prompt_len:]
+                    first_line = first_line[len(preceding_text) - prompt_len:]
 
                 # Remove partial prompt last line
                 if len(remaining_lines) > 0 and remaining_lines[-1]:

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -222,7 +222,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                 cursor.setPosition(cursor.selectionStart())
                 cursor.setPosition(cursor.block().position(),
                                    QtGui.QTextCursor.KeepAnchor)
-                preceding_text = cursor.selectedText()
+                preceding_text = cursor.selection().toPlainText()
 
                 def remove_prompts(line):
                     """Remove all prompts from line."""

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -215,24 +215,37 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         elif self._control.hasFocus():
             text = self._control.textCursor().selection().toPlainText()
             if text:
-                # Adjust the cursor to not take partial prompts
-                cursor = self._control.textCursor()
-                start_pos = cursor.selectionStart()
-                cursor.setPosition(start_pos)
-                if (cursor.blockNumber() >=
-                        self._get_prompt_cursor().blockNumber()):
-                    # Only remove partial prompt if in edit area
-                    line_prompt_pos = (
-                        cursor.block().position()
-                        + len(self._continuation_prompt))
-                    if start_pos < line_prompt_pos:
-                        text = text[(line_prompt_pos - start_pos):]
+                first_line_selection, *remaining_lines = text.splitlines()
 
-                # Remove prompts.
-                lines = text.splitlines()
-                lines = map(self._highlighter.transform_classic_prompt, lines)
-                lines = map(self._highlighter.transform_ipy_prompt, lines)
-                text = '\n'.join(lines)
+                # Get preceding text
+                cursor = self._control.textCursor()
+                cursor.setPosition(cursor.selectionStart())
+                cursor.setPosition(cursor.block().position(),
+                                   QtGui.QTextCursor.KeepAnchor)
+                preceding_text = cursor.selectedText()
+
+                # Get first line promp len
+                first_line = preceding_text + first_line_selection
+                len_with_prompt = len(first_line)
+                first_line = self._highlighter.transform_classic_prompt(
+                    first_line)
+                first_line = self._highlighter.transform_ipy_prompt(
+                    first_line)
+                prompt_len = len_with_prompt - len(first_line)
+
+                # Remove not selected part
+                if prompt_len < len(preceding_text):
+                    first_line = first_line[len(preceding_text)-prompt_len:]
+
+                # Remove prompts for other lines.
+                remaining_lines = map(
+                    self._highlighter.transform_classic_prompt,
+                    remaining_lines)
+                remaining_lines = map(
+                    self._highlighter.transform_ipy_prompt,
+                    remaining_lines)
+                text = '\n'.join([first_line, *remaining_lines])
+
                 # Needed to prevent errors when copying the prompt.
                 # See issue 264
                 try:

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -84,8 +84,8 @@ class TestJupyterWidget(unittest.TestCase):
             '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
         ))
 
-    def test_copy(self):
-        """Test copy removes partial and full prompts."""
+    def test_copy_paste(self):
+        """Test copy/paste removes partial and full prompts."""
         w = JupyterWidget(kind='rich')
         w._show_interpreter_prompt(1)
         control = w._control
@@ -105,3 +105,6 @@ class TestJupyterWidget(unittest.TestCase):
         w.copy()
         clipboard = QtWidgets.QApplication.clipboard()
         assert clipboard.text() == code
+        w.paste()
+        expected = "In [1]: if True:\n   ...:     print('a')"
+        assert expected in control.toPlainText()

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -1,6 +1,5 @@
 import unittest
 import sys
-from textwrap import dedent
 
 import pytest
 from qtpy import QtWidgets, QtGui

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -83,7 +83,7 @@ class TestJupyterWidget(unittest.TestCase):
             '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
         ))
 
-    def test_copy_paste(self):
+    def test_copy_paste_prompt(self):
         """Test copy/paste removes partial and full prompts."""
         w = JupyterWidget(kind='rich')
         w._show_interpreter_prompt(1)

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -1,8 +1,9 @@
 import unittest
 import sys
+from textwrap import dedent
 
 import pytest
-from qtpy import QtWidgets
+from qtpy import QtWidgets, QtGui
 
 from qtconsole.client import QtKernelClient
 from qtconsole.jupyter_widget import JupyterWidget
@@ -82,3 +83,25 @@ class TestJupyterWidget(unittest.TestCase):
             '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
             '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
         ))
+
+    def test_copy(self):
+        """Test copy removes partial and full prompts."""
+        w = JupyterWidget(kind='rich')
+        w._show_interpreter_prompt(1)
+        control = w._control
+
+        code = "    if True:\n        print('a')"
+        w._set_input_buffer(code)
+        assert code not in control.toPlainText()
+
+        cursor = w._get_prompt_cursor()
+
+        pos = cursor.position()
+        cursor.setPosition(pos - 3)
+        cursor.movePosition(QtGui.QTextCursor.End,
+                            QtGui.QTextCursor.KeepAnchor)
+        control.setTextCursor(cursor)
+        control.hasFocus = lambda: True
+        w.copy()
+        clipboard = QtWidgets.QApplication.clipboard()
+        assert clipboard.text() == code


### PR DESCRIPTION
When copying, qtconsole removes whole prompts, but not partial prompts. This removes partial prompts on the first line.