### PR TITLE
Fix launching issue with Big Sur

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -7,6 +7,7 @@ input, there is no real readline support, among other limitations.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from distutils.version import LooseVersion
 import os
 import signal
 import sys
@@ -57,7 +58,7 @@ if os.name == 'nt':
     except AttributeError:
         pass
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION
 
 from traitlets.config.application import boolean_flag
 from traitlets.config.application import catch_config_error
@@ -410,6 +411,10 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
 
     @catch_config_error
     def initialize(self, argv=None):
+        # Fixes launching issues with Big Sur
+        # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
+        if sys.platform == 'darwin' and LooseVersion(QT_VERSION) < LooseVersion('5.15.2'):
+            os.environ['QT_MAC_WANTS_LAYER'] = '1'
         self._init_asyncio_patch()
         self.init_qt_app()
         super().initialize(argv)


### PR DESCRIPTION
Similar fixes as in https://github.com/spyder-ide/spyder/pull/14256. 

Relevant links:
https://bugreports.qt.io/browse/QTBUG-87014
https://github.com/matplotlib/matplotlib/issues/18954

It is fixed in qt 5.15.2 (https://codereview.qt-project.org/c/qt/qtbase/+/322228) and in the coming 5.12.11 (https://codereview.qt-project.org/c/qt/qtbase/+/322507) and confirmed in https://stackoverflow.com/questions/64818879/is-there-any-solution-regarding-to-pyqt-library-doesnt-work-in-mac-os-big-sur/64856281 that setting this environment variable is not necessary for qt >=5.15.2.