### PR TITLE
Emit kernel_restarted only after crashing

### DIFF
--- a/qtconsole/manager.py
+++ b/qtconsole/manager.py
@@ -38,6 +38,7 @@ class QtKernelManager(KernelManager, QtKernelManagerMixin):
         self._is_restarting = False
 
     def start_restarter(self):
+        """Start restarter mechanism."""
         if self.autorestart and self.has_kernel:
             if self._restarter is None:
                 self._restarter = QtKernelRestarter(
@@ -45,16 +46,22 @@ class QtKernelManager(KernelManager, QtKernelManagerMixin):
                     parent=self,
                     log=self.log,
                 )
-            self._is_restarting = True
+                self._restarter.add_callback(self._handle_kernel_restarting)
             self._restarter.start()
 
     def stop_restarter(self):
+        """Stop restarter mechanism."""
         if self.autorestart:
             if self._restarter is not None:
                 self._restarter.stop()
 
     def post_start_kernel(self, **kw):
+        """Kernel restarted."""
         super().post_start_kernel(**kw)
         if self._is_restarting:
             self.kernel_restarted.emit()
             self._is_restarting = False
+
+    def _handle_kernel_restarting(self):
+        """Kernel has died, and will be restarted."""
+        self._is_restarting = True


### PR DESCRIPTION
`kernel_restarted` should only be emitted when the kernel dies and restart, but is now emitted on any restart following #450. This solves this issue, and fixes https://github.com/spyder-ide/spyder/issues/14886 