### PR TITLE
Destroy CallTipWidget when corresponding TextEdit is destroyed

### DIFF
--- a/qtconsole/call_tip_widget.py
+++ b/qtconsole/call_tip_widget.py
@@ -20,6 +20,7 @@ class CallTipWidget(QtWidgets.QLabel):
         """
         assert isinstance(text_edit, (QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit))
         super().__init__(None, QtCore.Qt.ToolTip)
+        text_edit.destroyed.connect(lambda: self.deleteLater())
 
         self._hide_timer = QtCore.QBasicTimer()
         self._text_edit = text_edit


### PR DESCRIPTION
The CallTipWidget acts like a tooltip and has no parent. As such,
it would be leaked without this explicit lifetime management.