### PR TITLE
Fix DeprecationWarning: invalid escape sequence.

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -43,8 +43,8 @@ BackSpaceAction = namedtuple('BackSpaceAction', ['action'])
 
 # Regular expressions.
 CSI_COMMANDS = 'ABCDEFGHJKSTfmnsu'
-CSI_SUBPATTERN = '\[(.*?)([%s])' % CSI_COMMANDS
-OSC_SUBPATTERN = '\](.*?)[\x07\x1b]'
+CSI_SUBPATTERN = '\\[(.*?)([%s])' % CSI_COMMANDS
+OSC_SUBPATTERN = '\\](.*?)[\x07\x1b]'
 ANSI_PATTERN = ('\x01?\x1b(%s|%s)\x02?' % \
                 (CSI_SUBPATTERN, OSC_SUBPATTERN))
 ANSI_OR_SPECIAL_PATTERN = re.compile('(\a|\b|\r(?!\n)|\r?\n)|(?:%s)' % ANSI_PATTERN)


### PR DESCRIPTION
Replace \, by \\, which is how python currently interprets it.
r"" would be incorrect as the \x1b would be escaped.

Checked that ANSI_PATTERN is unchanged to:

In [7]: ANSI_PATTERN
Out[7]: '\x01?\x1b(\\[(.*?)([ABCDEFGHJKSTfmnsu])|\\](.*?)[\x07\x1b])\x02?'