### PR TITLE
Fix ANSI code "Erase in Line"

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -144,7 +144,6 @@ class AnsiCodeProcessor(object):
         substring = SPECIAL_PATTERN.sub(self._replace_special, raw)
         if substring or self.actions:
             yield substring
-            self.actions = []
 
         if last_char is not None:
             self.actions.append(NewLineAction('newline'))

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -144,6 +144,7 @@ class AnsiCodeProcessor(object):
         substring = SPECIAL_PATTERN.sub(self._replace_special, raw)
         if substring or self.actions:
             yield substring
+            self.actions = []
 
         if last_char is not None:
             self.actions.append(NewLineAction('newline'))

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2181,11 +2181,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 if substring is not None:
                     format = self._ansi_processor.get_format()
                     pos = cursor.position()
-                    remain=self._get_line_end_pos()-pos
+                    cursor.movePosition(cursor.EndOfLine, cursor.KeepAnchor) # select remaining line
+                    remain=cursor.selectionEnd()-cursor.selectionStart()
                     n=len(substring)
                     swallow=min(n,remain) 
-                    cursor.setPosition(pos+swallow,cursor.KeepAnchor)
-                    cursor.insertText(substring, format)
+                    cursor.setPosition(pos+swallow)
+                    cursor.setPosition(pos,cursor.KeepAnchor)
+                    cursor.insertText(substring,format)
         else:
             cursor.insertText(text)
         cursor.endEditBlock()

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2181,11 +2181,10 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 if substring is not None:
                     format = self._ansi_processor.get_format()
                     pos = cursor.position()
-                    cursor.movePosition(cursor.EndOfLine, cursor.KeepAnchor) # select remaining line
-                    remain=cursor.selectionEnd()-cursor.selectionStart()
+                    remain=self._get_line_end_pos()-pos
                     n=len(substring)
-                    if n<remain: cursor.setPosition(pos+remain-n+1)
-                    cursor.setPosition(pos,cursor.KeepAnchor)
+                    swallow=min(n,remain) 
+                    cursor.setPosition(pos+swallow,cursor.KeepAnchor)
                     cursor.insertText(substring, format)
         else:
             cursor.insertText(text)

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2128,9 +2128,27 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     # Unlike real terminal emulators, we don't distinguish
                     # between the screen and the scrollback buffer. A screen
                     # erase request clears everything.
-                    if act.action == 'erase' and act.area == 'screen':
-                        cursor.select(QtGui.QTextCursor.Document)
-                        cursor.removeSelectedText()
+                    if act.action == 'erase':
+                        remove = False
+                        fill = False
+                        if act.area == 'screen':
+                            cursor.select(cursor.Document)
+                            remove = True
+                        if act.area == 'line':
+                            if act.erase_to == 'all': 
+                                cursor.select(cursor.LineUnderCursor)
+                                remove = True
+                            elif act.erase_to == 'start':
+                                cursor.movePosition(cursor.StartOfLine, cursor.KeepAnchor)
+                                remove = True
+                                fill = True
+                            elif act.erase_to == 'end':
+                                cursor.movePosition(cursor.EndOfLine, cursor.KeepAnchor)
+                                remove = True
+                        if remove: 
+                            nspace=cursor.selectionEnd()-cursor.selectionStart() if fill else 0
+                            cursor.removeSelectedText()
+                            if nspace>0: cursor.insertText(' '*nspace) # replace text by space, to keep cursor position as specified
 
                     # Simulate a form feed by scrolling just past the last line.
                     elif act.action == 'scroll' and act.unit == 'page':
@@ -2141,12 +2159,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                         cursor.deletePreviousChar()
 
                         if os.name == 'nt':
-                            cursor.select(QtGui.QTextCursor.Document)
+                            cursor.select(cursor.Document)
                             cursor.removeSelectedText()
 
                     elif act.action == 'carriage-return':
                         cursor.movePosition(
-                            cursor.StartOfLine, cursor.KeepAnchor)
+                            cursor.StartOfLine, cursor.MoveAnchor)
 
                     elif act.action == 'beep':
                         QtWidgets.QApplication.instance().beep()
@@ -2154,28 +2172,21 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     elif act.action == 'backspace':
                         if not cursor.atBlockStart():
                             cursor.movePosition(
-                                cursor.PreviousCharacter, cursor.KeepAnchor)
+                                cursor.PreviousCharacter, cursor.MoveAnchor)
 
                     elif act.action == 'newline':
                         cursor.movePosition(cursor.EndOfLine)
 
-                format = self._ansi_processor.get_format()
-
-                selection = cursor.selectedText()
-                if len(selection) == 0:
+                # simulate replacement mode
+                if substring is not None:
+                    format = self._ansi_processor.get_format()
+                    pos = cursor.position()
+                    cursor.movePosition(cursor.EndOfLine, cursor.KeepAnchor) # select remaining line
+                    remain=cursor.selectionEnd()-cursor.selectionStart()
+                    n=len(substring)
+                    if n<remain: cursor.setPosition(pos+remain-n+1)
+                    cursor.setPosition(pos,cursor.KeepAnchor)
                     cursor.insertText(substring, format)
-                elif substring is not None:
-                    # BS and CR are treated as a change in print
-                    # position, rather than a backwards character
-                    # deletion for output equivalence with (I)Python
-                    # terminal.
-                    if len(substring) >= len(selection):
-                        cursor.insertText(substring, format)
-                    else:
-                        old_text = selection[len(substring):]
-                        cursor.insertText(substring + old_text, format)
-                        cursor.movePosition(cursor.PreviousCharacter,
-                               cursor.KeepAnchor, len(old_text))
         else:
             cursor.insertText(text)
         cursor.endEditBlock()

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -984,6 +984,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         cursor = self._control.textCursor()
         if before_prompt and (self._reading or not self._executing):
             self._flush_pending_stream()
+            cursor._insert_mode=True
             cursor.setPosition(self._append_before_prompt_pos)
         else:
             if insert != self._insert_plain_text:
@@ -2180,13 +2181,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 # simulate replacement mode
                 if substring is not None:
                     format = self._ansi_processor.get_format()
-                    pos = cursor.position()
-                    cursor.movePosition(cursor.EndOfLine, cursor.KeepAnchor) # select remaining line
-                    remain=cursor.selectionEnd()-cursor.selectionStart()
-                    n=len(substring)
-                    swallow=min(n,remain) 
-                    cursor.setPosition(pos+swallow)
-                    cursor.setPosition(pos,cursor.KeepAnchor)
+                    if not (hasattr(cursor,'_insert_mode') and cursor._insert_mode):
+                        pos = cursor.position()
+                        remain=self._get_line_end_pos()-pos
+                        n=len(substring)
+                        swallow=min(n,remain)
+                        cursor.setPosition(pos+swallow,cursor.KeepAnchor)
                     cursor.insertText(substring,format)
         else:
             cursor.insertText(text)

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -246,6 +246,31 @@ class TestConsoleWidget(unittest.TestCase):
             # clear all the text
             cursor.insertText('')
 
+    def test_erase_in_line(self):
+        """ Do control sequences for clearing the line work?
+        """
+        w = ConsoleWidget()
+        cursor = w._get_prompt_cursor()
+
+        test_inputs = ['Hello\x1b[1KBye',
+                       'Hello\x1b[0KBye',
+                       'Hello\r\x1b[0KBye',
+                       'Hello\r\x1b[1KBye',
+                       'Hello\r\x1b[2KBye',
+                       'Hello\x1b[2K\rBye']
+
+        expected_outputs = ['     Bye',
+                            'HelloBye',
+                            'Bye',
+                            'Byelo',
+                            'Bye',
+                            'Bye']
+        for i, text in enumerate(test_inputs):
+            w._insert_plain_text(cursor, text)
+            self.assert_text_equal(cursor, expected_outputs[i])
+            # clear all the text
+            cursor.insertText('')
+
     def test_link_handling(self):
         noKeys = QtCore.Qt
         noButton = QtCore.Qt.MouseButton(0)

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -31,6 +31,8 @@ class TestAnsiCodeProcessor(unittest.TestCase):
             else:
                 self.fail('Too many substrings.')
         self.assertEqual(i, 1, 'Too few substrings.')
+    
+    #test_erase_in_line() is in test_00_console_widget.py, because it needs the console
 
     def test_colors(self):
         """ Do basic controls sequences for colors work?


### PR DESCRIPTION
It is related to #350.
It now fixes the K ANSI code (Erase in Line) supporting:

-  0K for 'until end', 
- 1K for 'until start', 
- 2K for all line (whole). 

1/ I hope my code does not break anything; it can, as I had to change '\r' carriage return & '\b' that strangely used to keep the cursor in position.  Somehow I have implemented a more natural 'replace text' mode (instead than default insert mode).

2/ There was a misunderstanding of the specs requiring not to move the cursor ([ANSI code](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences)).
Therefore I had also to replace sometimes the removed text by spaces.

I guess it is WIP.

Some examples, giving similar results in Python & IPython, AFAI've checked.
```
print('Hello\x1b[1KBye')    # "     Bye"
print('Hello\x1b[0KBye')    # "HelloBye"
print('Hello\r\x1b[0KBye')  # "Bye"
print('Hello\r\x1b[1KBye')  # "Byelo"
print('Hello\r\x1b[2KBye')  # "Bye"
print('Hello\x1b[2K\rBye')  # "Bye"
```