### PR TITLE
Fix hidden execution requests

### DIFF
--- a/qtconsole/base_frontend_mixin.py
+++ b/qtconsole/base_frontend_mixin.py
@@ -144,7 +144,9 @@ class BaseFrontendMixin(object):
 
     def include_output(self, msg):
         """Return whether we should include a given output message"""
-        if self._hidden:
+        msg_id = msg['parent_header']['msg_id']
+        info = self._request_info['execute'].get(msg_id)
+        if info and info.hidden:
             return False
         from_here = self.from_here(msg)
         if msg['msg_type'] == 'execute_input':

--- a/qtconsole/base_frontend_mixin.py
+++ b/qtconsole/base_frontend_mixin.py
@@ -145,7 +145,7 @@ class BaseFrontendMixin(object):
     def include_output(self, msg):
         """Return whether we should include a given output message"""
         if msg['parent_header']:
-            # If parent message is from hidden execution, do not include
+            # If parent message is from hidden execution, don't include it.
             msg_id = msg['parent_header']['msg_id']
             info = self._request_info['execute'].get(msg_id)
             if info and info.hidden:

--- a/qtconsole/base_frontend_mixin.py
+++ b/qtconsole/base_frontend_mixin.py
@@ -144,10 +144,12 @@ class BaseFrontendMixin(object):
 
     def include_output(self, msg):
         """Return whether we should include a given output message"""
-        msg_id = msg['parent_header']['msg_id']
-        info = self._request_info['execute'].get(msg_id)
-        if info and info.hidden:
-            return False
+        if msg['parent_header']:
+            # If parent message is from hidden execution, do not include
+            msg_id = msg['parent_header']['msg_id']
+            info = self._request_info['execute'].get(msg_id)
+            if info and info.hidden:
+                return False
         from_here = self.from_here(msg)
         if msg['msg_type'] == 'execute_input':
             # only echo inputs not from here

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -152,7 +152,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     _CallTipRequest = namedtuple('_CallTipRequest', ['id', 'pos'])
     _CompletionRequest = namedtuple('_CompletionRequest',
                                     ['id', 'code', 'pos'])
-    _ExecutionRequest = namedtuple('_ExecutionRequest', ['id', 'kind'])
+    _ExecutionRequest = namedtuple(
+        '_ExecutionRequest', ['id', 'kind', 'hidden'])
     _local_kernel = False
     _highlighter = Instance(FrontendHighlighter, allow_none=True)
 
@@ -166,7 +167,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self._bracket_matcher = BracketMatcher(self._control)
         self._call_tip_widget = CallTipWidget(self._control)
         self._copy_raw_action = QtWidgets.QAction('Copy (Raw Text)', None)
-        self._hidden = False
         self._highlighter = FrontendHighlighter(self, lexer=self.lexer)
         self._kernel_manager = None
         self._kernel_client = None
@@ -283,8 +283,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         See parent class :meth:`execute` docstring for full details.
         """
         msg_id = self.kernel_client.execute(source, hidden)
-        self._request_info['execute'][msg_id] = self._ExecutionRequest(msg_id, 'user')
-        self._hidden = hidden
+        self._request_info['execute'][msg_id] = self._ExecutionRequest(
+            msg_id, 'user', hidden)
         if not hidden:
             self.executing.emit(source)
 
@@ -419,7 +419,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         msg_id = self.kernel_client.execute('',
             silent=True, user_expressions={ local_uuid:expr })
         self._callback_dict[local_uuid] = callback
-        self._request_info['execute'][msg_id] = self._ExecutionRequest(msg_id, 'silent_exec_callback')
+        self._request_info['execute'][msg_id] = self._ExecutionRequest(
+            msg_id, 'silent_exec_callback', True)
 
     def _handle_exec_callback(self, msg):
         """Execute `callback` corresponding to `msg` reply, after ``_silent_exec_callback``
@@ -455,7 +456,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # still be pending.
         self._reading = False
         # Note:  If info is NoneType, this is ignored
-        if info and info.kind == 'user' and not self._hidden:
+        if not info:
+            return
+        if info.kind == 'user' and not info.hidden:
             # Make sure that all output from the SUB channel has been processed
             # before writing a new prompt.
             self.kernel_client.iopub_channel.flush()
@@ -476,10 +479,10 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self._show_interpreter_prompt_for_reply(msg)
             self.executed.emit(msg)
             self._request_info['execute'].pop(msg_id)
-        elif info and info.kind == 'silent_exec_callback' and not self._hidden:
+        elif info.kind == 'silent_exec_callback' and not info.hidden:
             self._handle_exec_callback(msg)
             self._request_info['execute'].pop(msg_id)
-        elif info and not self._hidden:
+        elif not info.hidden:
             raise RuntimeError("Unknown handler for %s" % info.kind)
 
     def _handle_error(self, msg):
@@ -491,7 +494,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Handle requests for raw_input.
         """
         self.log.debug("input: %s", msg.get('content', ''))
-        if self._hidden:
+        msg_id = msg['parent_header']['msg_id']
+        info = self._request_info['execute'].get(msg_id)
+        if info and info.hidden:
             raise RuntimeError('Request for raw input during hidden execution.')
 
         # Make sure that all output from the SUB channel has been processed
@@ -564,7 +569,10 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.debug("shutdown: %s", msg.get('content', ''))
         restart = msg.get('content', {}).get('restart', False)
-        if not self._hidden and not self.from_here(msg):
+        msg_id = msg['parent_header']['msg_id']
+        info = self._request_info['execute'].get(msg_id)
+        hidden = info and info.hidden
+        if not hidden and not self.from_here(msg):
             # got shutdown reply, request came from session other than ours
             if restart:
                 # someone restarted the kernel, handle it

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -569,10 +569,12 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.debug("shutdown: %s", msg.get('content', ''))
         restart = msg.get('content', {}).get('restart', False)
-        msg_id = msg['parent_header']['msg_id']
-        info = self._request_info['execute'].get(msg_id)
-        hidden = info and info.hidden
-        if not hidden and not self.from_here(msg):
+        if msg['parent_header']:
+            msg_id = msg['parent_header']['msg_id']
+            info = self._request_info['execute'].get(msg_id)
+            if info and info.hidden:
+                return
+        if not self.from_here(msg):
             # got shutdown reply, request came from session other than ours
             if restart:
                 # someone restarted the kernel, handle it

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -456,9 +456,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # still be pending.
         self._reading = False
         # Note:  If info is NoneType, this is ignored
-        if not info:
+        if not info or info.hidden:
             return
-        if info.kind == 'user' and not info.hidden:
+        if info.kind == 'user':
             # Make sure that all output from the SUB channel has been processed
             # before writing a new prompt.
             self.kernel_client.iopub_channel.flush()
@@ -479,10 +479,10 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self._show_interpreter_prompt_for_reply(msg)
             self.executed.emit(msg)
             self._request_info['execute'].pop(msg_id)
-        elif info.kind == 'silent_exec_callback' and not info.hidden:
+        elif info.kind == 'silent_exec_callback':
             self._handle_exec_callback(msg)
             self._request_info['execute'].pop(msg_id)
-        elif not info.hidden:
+        else:
             raise RuntimeError("Unknown handler for %s" % info.kind)
 
     def _handle_error(self, msg):

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -420,7 +420,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             silent=True, user_expressions={ local_uuid:expr })
         self._callback_dict[local_uuid] = callback
         self._request_info['execute'][msg_id] = self._ExecutionRequest(
-            msg_id, 'silent_exec_callback', True)
+            msg_id, 'silent_exec_callback', False)
 
     def _handle_exec_callback(self, msg):
         """Execute `callback` corresponding to `msg` reply, after ``_silent_exec_callback``

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -372,7 +372,7 @@ class JupyterWidget(IPythonWidget):
         # If a number was not specified, make a prompt number request.
         if number is None:
             msg_id = self.kernel_client.execute('', silent=True)
-            info = self._ExecutionRequest(msg_id, 'prompt')
+            info = self._ExecutionRequest(msg_id, 'prompt', True)
             self._request_info['execute'][msg_id] = info
             return
 

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -135,6 +135,7 @@ class JupyterWidget(IPythonWidget):
 
         # Initialize language name.
         self.language_name = None
+        self._prompt_requested = False
 
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface
@@ -183,6 +184,7 @@ class JupyterWidget(IPythonWidget):
         msg_id = msg['parent_header'].get('msg_id')
         info = self._request_info['execute'].get(msg_id)
         if info and info.kind == 'prompt':
+            self._prompt_requested = False
             content = msg['content']
             if content['status'] == 'aborted':
                 self._show_interpreter_prompt()
@@ -371,6 +373,10 @@ class JupyterWidget(IPythonWidget):
         """
         # If a number was not specified, make a prompt number request.
         if number is None:
+            if self._prompt_requested:
+                # Already asked for prompt, avoid multiple prompts.
+                return
+            self._prompt_requested = True
             msg_id = self.kernel_client.execute('', silent=True)
             info = self._ExecutionRequest(msg_id, 'prompt', True)
             self._request_info['execute'][msg_id] = info

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -378,7 +378,7 @@ class JupyterWidget(IPythonWidget):
                 return
             self._prompt_requested = True
             msg_id = self.kernel_client.execute('', silent=True)
-            info = self._ExecutionRequest(msg_id, 'prompt', True)
+            info = self._ExecutionRequest(msg_id, 'prompt', False)
             self._request_info['execute'][msg_id] = info
             return
 


### PR DESCRIPTION
The requests are not necessarily sent after receiving the reply from the previous request. If several request are sent in rapid succession, `self._hidden` becomes meaningless. The hidden state of each request must therefore be saved.

Also, the prompt was sometimes requested several times, so to avoid multiple confusing prompt, a check is added.