### PR TITLE
Fix 'Erase in Line' ANSI code

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2183,7 +2183,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     format = self._ansi_processor.get_format()
                     if not (hasattr(cursor,'_insert_mode') and cursor._insert_mode):
                         pos = cursor.position()
-                        remain=self._get_line_end_pos()-pos # could be negative ! As not taking int account last \n ?
+                        remain = self._get_line_end_pos() - pos  # It could be negative! As not taking into account the last \n?
                         n=len(substring)
                         swallow=max(0,min(n,remain))
                         cursor.setPosition(pos+swallow,cursor.KeepAnchor)

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2183,9 +2183,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     format = self._ansi_processor.get_format()
                     if not (hasattr(cursor,'_insert_mode') and cursor._insert_mode):
                         pos = cursor.position()
-                        remain=self._get_line_end_pos()-pos
+                        remain=self._get_line_end_pos()-pos # could be negative ! As not taking int account last \n ?
                         n=len(substring)
-                        swallow=min(n,remain)
+                        swallow=max(0,min(n,remain))
                         cursor.setPosition(pos+swallow,cursor.KeepAnchor)
                     cursor.insertText(substring,format)
         else:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2185,7 +2185,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                         pos = cursor.position()
                         remain = self._get_line_end_pos() - pos  # It could be negative! As not taking into account the last \n?
                         n=len(substring)
-                        swallow=max(0,min(n,remain))
+                        swallow = max(0, min(n, remain))
                         cursor.setPosition(pos+swallow,cursor.KeepAnchor)
                     cursor.insertText(substring,format)
         else:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2183,9 +2183,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                     format = self._ansi_processor.get_format()
                     if not (hasattr(cursor,'_insert_mode') and cursor._insert_mode):
                         pos = cursor.position()
-                        remain = self._get_line_end_pos() - pos  # It could be negative! As not taking into account the last \n?
+                        cursor2 = QtGui.QTextCursor(cursor)  # self._get_line_end_pos() is the previous line, don't use it
+                        cursor2.movePosition(cursor2.EndOfLine)
+                        remain = cursor2.position() - pos    # number of characters until end of line
                         n=len(substring)
-                        swallow = max(0, min(n, remain))
+                        swallow = min(n, remain)             # number of character to swallow
                         cursor.setPosition(pos+swallow,cursor.KeepAnchor)
                     cursor.insertText(substring,format)
         else:


### PR DESCRIPTION
There was an issue when pressing left key before newline, eg:
`In [1]: print('foo')`
would have printed
`In[1]: print('foo')foo`

However the CI tests were successful and I did not add a new one for this case (my apologize).