### PR TITLE
Get latex_to_png foreground color from stylesheet

### DIFF
--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -212,21 +212,24 @@ class RichJupyterWidget(RichIPythonWidget):
                 return True
         return False
 
+    def _get_colors(self, color):
+        return get_colors(self.syntax_style)[color]
+
     def _append_latex(self, latex, before_prompt=False, metadata=None):
         """ Append latex data to the widget."""
         png = None
 
-        fgcolor = get_colors(self.syntax_style)['fgcolor']
-
         if self._is_latex_math(latex):
-            png = latex_to_png(latex, wrap=False, backend='dvipng', color=fgcolor)
+            png = latex_to_png(latex, wrap=False, backend='dvipng',
+                               color=self._get_colors('fgcolor'))
 
         # Matplotlib only supports strings enclosed in dollar signs
         if png is None and latex.startswith('$') and latex.endswith('$'):
             # To avoid long and ugly errors, like the one reported in
             # spyder-ide/spyder#7619
             try:
-                png = latex_to_png(latex, wrap=False, backend='matplotlib', color=fgcolor)
+                png = latex_to_png(latex, wrap=False, backend='matplotlib',
+                                   color=self._get_colors('fgcolor'))
             except Exception:
                 pass
 

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -10,6 +10,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 from ipython_genutils.path import ensure_dir_exists
 from traitlets import Bool
+from pygments.util import ClassNotFound
 from qtconsole.svg import save_svg, svg_to_clipboard, svg_to_image
 from .jupyter_widget import JupyterWidget
 from .styles import get_colors
@@ -213,7 +214,13 @@ class RichJupyterWidget(RichIPythonWidget):
         return False
 
     def _get_colors(self, color):
-        return get_colors(self.syntax_style)[color]
+        """Get colors from the current syntax style if loadable"""
+        try:
+            return get_colors(self.syntax_style)[color]
+        except ClassNotFound:
+            # the syntax_style has been sideloaded (e.g. by spyder)
+            # in this case the overloading class should override this method
+            return get_colors('default')[color]
 
     def _append_latex(self, latex, before_prompt=False, metadata=None):
         """ Append latex data to the widget."""

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -12,7 +12,7 @@ from ipython_genutils.path import ensure_dir_exists
 from traitlets import Bool
 from qtconsole.svg import save_svg, svg_to_clipboard, svg_to_image
 from .jupyter_widget import JupyterWidget
-
+from .styles import get_colors
 
 try:
     from IPython.lib.latextools import latex_to_png
@@ -216,15 +216,17 @@ class RichJupyterWidget(RichIPythonWidget):
         """ Append latex data to the widget."""
         png = None
 
+        fgcolor = get_colors(self.syntax_style)['fgcolor']
+
         if self._is_latex_math(latex):
-            png = latex_to_png(latex, wrap=False, backend='dvipng')
+            png = latex_to_png(latex, wrap=False, backend='dvipng', color=fgcolor)
 
         # Matplotlib only supports strings enclosed in dollar signs
         if png is None and latex.startswith('$') and latex.endswith('$'):
             # To avoid long and ugly errors, like the one reported in
             # spyder-ide/spyder#7619
             try:
-                png = latex_to_png(latex, wrap=False, backend='matplotlib')
+                png = latex_to_png(latex, wrap=False, backend='matplotlib', color=fgcolor)
             except Exception:
                 pass
 

--- a/qtconsole/rich_jupyter_widget.py
+++ b/qtconsole/rich_jupyter_widget.py
@@ -11,6 +11,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 from ipython_genutils.path import ensure_dir_exists
 from traitlets import Bool
 from pygments.util import ClassNotFound
+
 from qtconsole.svg import save_svg, svg_to_clipboard, svg_to_image
 from .jupyter_widget import JupyterWidget
 from .styles import get_colors
@@ -213,13 +214,13 @@ class RichJupyterWidget(RichIPythonWidget):
                 return True
         return False
 
-    def _get_colors(self, color):
-        """Get colors from the current syntax style if loadable"""
+    def _get_color(self, color):
+        """Get color from the current syntax style if loadable."""
         try:
             return get_colors(self.syntax_style)[color]
         except ClassNotFound:
-            # the syntax_style has been sideloaded (e.g. by spyder)
-            # in this case the overloading class should override this method
+            # The syntax_style has been sideloaded (e.g. by spyder).
+            # In this case the overloading class should override this method.
             return get_colors('default')[color]
 
     def _append_latex(self, latex, before_prompt=False, metadata=None):
@@ -228,7 +229,7 @@ class RichJupyterWidget(RichIPythonWidget):
 
         if self._is_latex_math(latex):
             png = latex_to_png(latex, wrap=False, backend='dvipng',
-                               color=self._get_colors('fgcolor'))
+                               color=self._get_color('fgcolor'))
 
         # Matplotlib only supports strings enclosed in dollar signs
         if png is None and latex.startswith('$') and latex.endswith('$'):
@@ -236,7 +237,7 @@ class RichJupyterWidget(RichIPythonWidget):
             # spyder-ide/spyder#7619
             try:
                 png = latex_to_png(latex, wrap=False, backend='matplotlib',
-                                   color=self._get_colors('fgcolor'))
+                                   color=self._get_color('fgcolor'))
             except Exception:
                 pass
 


### PR DESCRIPTION
Since [7.8.0](https://github.com/ipython/ipython/pull/11840), `IPython's latextool.latex_to_png()` has a `color` keyword for setting the foreground color. Let's use it.

This resolves style problems for any `_latex_repr_()` rendering which does not come from SymPy, e.g. Astropy or python-control.

```python
In [1]: from control import rss

In [2]: randomstatespace = rss(3,2,1)

In [3]: randomstatespace._repr_latex_()
Out[3]: '\\[\n\\left(\n\\begin{array}{rllrllrll|rll}\n-1.&\\hspace{-1em}79&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}279&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}77&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}223&\\hspace{-1em}\\phantom{\\cdot}\\\\\n-0.&\\hspace{-1em}652&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}51&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}36&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}128&\\hspace{-1em}\\phantom{\\cdot}\\\\\n0.&\\hspace{-1em}835&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}181&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}711&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}495&\\hspace{-1em}\\phantom{\\cdot}\\\\\n\\hline\n-0.&\\hspace{-1em}00268&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}855&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}0902&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}852&\\hspace{-1em}\\phantom{\\cdot}\\\\\n-0.&\\hspace{-1em}762&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}0347&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}472&\\hspace{-1em}\\phantom{\\cdot}&1.&\\hspace{-1em}34&\\hspace{-1em}\\phantom{\\cdot}\\\\\n\\end{array}\\right)\n\\]'
```

QtConsole with solarized-dark theme:

| before | after | after +  dvipng transparency fix in IPython (https://github.com/ipython/ipython/pull/13372) |
| ---- | ----| --- |
| ![image](https://user-images.githubusercontent.com/4623504/144717232-5c24cae4-4604-4a35-bccd-dba7ba8d6ca1.png) | ![image](https://user-images.githubusercontent.com/4623504/144717246-be2ab2b2-0f92-4ab9-83ba-3ed8d153e542.png) | ![image](https://user-images.githubusercontent.com/4623504/144717259-a5b8695f-852f-49be-ac36-b2ce6418c6fa.png) |


Related:
- https://github.com/ipython/ipython/issues/9451
- https://github.com/spyder-ide/spyder/issues/3798#issuecomment-776939312
- https://github.com/python-control/python-control/issues/658
- https://github.com/astropy/astropy/issues/11209