### PR TITLE
Fix implicit int to float conversion

### DIFF
--- a/qtconsole/completion_widget.py
+++ b/qtconsole/completion_widget.py
@@ -136,7 +136,7 @@ class CompletionWidget(QtWidgets.QListWidget):
         if (screen_rect.size().height() + screen_rect.y() -
                 point.y() - height < 0):
             point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
-            point.setY(point.y() - height)
+            point.setY(int(point.y() - height))
         w = (self.sizeHintForColumn(0) +
              self.verticalScrollBar().sizeHint().width() +
              2 * self.frameWidth())
@@ -168,7 +168,7 @@ class CompletionWidget(QtWidgets.QListWidget):
             delta = int((point_size * 1.20) ** 0.98)
 
         y = delta - (point_size / 2)
-        point.setY(point.y() + y)
+        point.setY(int(point.y() + y))
         point = self._text_edit.mapToGlobal(point)
         return point
 


### PR DESCRIPTION
Implicit conversion to integers using __int__ was deprecated, and now removed in Python 3.10.

Running tests in 3.9:
```
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_common_path_complete
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_droplist_completer_keyboard
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_droplist_completer_keyboard
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_droplist_completer_mousepick
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_droplist_completer_mousepick
qtconsole/tests/test_completion_widget.py::TestCompletionWidget::test_droplist_completer_shows
  /build/python-qtconsole/src/qtconsole-5.2.1/qtconsole/completion_widget.py:171: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
    point.setY(point.y() + y)
```
In 3.10:
```
________________ TestCompletionWidget.test_common_path_complete ________________

self = <qtconsole.tests.test_completion_widget.TestCompletionWidget testMethod=test_common_path_complete>

    def test_common_path_complete(self):
        with TemporaryDirectory() as tmpdir:
            items = [
                os.path.join(tmpdir, "common/common1/item1"),
                os.path.join(tmpdir, "common/common1/item2"),
                os.path.join(tmpdir, "common/common1/item3")]
            for item in items:
                os.makedirs(item)
            w = CompletionWidget(self.console)
>           w.show_items(self.text_edit.textCursor(), items)

qtconsole/tests/test_completion_widget.py:92: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
qtconsole/completion_widget.py:107: in show_items
    point = self._get_top_left_position(cursor)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <qtconsole.completion_widget.CompletionWidget object at 0x7fdbf81970a0>
cursor = <PyQt5.QtGui.QTextCursor object at 0x7fdbf824ad50>

    def _get_top_left_position(self, cursor):
        """ Get top left position for this widget.
        """
        point = self._text_edit.cursorRect(cursor).center()
        point_size = self._text_edit.font().pointSize()
    
        if sys.platform == 'darwin':
            delta = int((point_size * 1.20) ** 0.98)
        elif os.name == 'nt':
            delta = int((point_size * 1.20) ** 1.05)
        else:
            delta = int((point_size * 1.20) ** 0.98)
    
        y = delta - (point_size / 2)
>       point.setY(point.y() + y)
E       TypeError: setY(self, int): argument 1 has unexpected type 'float'

qtconsole/completion_widget.py:171: TypeError
```

I don’t know whether this is the proper fix, but it does what was implicitly done before.