### PR TITLE
Run tests with Python 3.10

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
         INSTALL_TYPE: ['conda', 'pip']
         QT_LIB: ['pyqt5', 'pyqt6']
         exclude:
-          - INSTALL_TYPE: conda
-            QT_LIB: pyqt6
+          - INSTALL_TYPE: 'conda'
+            QT_LIB: 'pyqt6'
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3


### PR DESCRIPTION
qtconsole supports python 3.10 as shown in the setup.py:

https://github.com/jupyter/qtconsole/blob/cbffab2e0368fa42a6e10d0427c74aceaa1ee3d3/setup.py#L99

But the GitHub workflow doesn't cover them. This PR tries to solve that problem.