### PR TITLE
Remove scripts that are duplicate to entry points in setup.py

### DIFF
--- a/scripts/jupyter-qtconsole
+++ b/scripts/jupyter-qtconsole
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from qtconsole.qtconsoleapp import main
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ PY3 = (sys.version_info[0] >= 3)
 # get on with it
 #-----------------------------------------------------------------------------
 
-from glob import glob
 import io
 import os
 
@@ -53,7 +52,6 @@ with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 setup_args = dict(
     name                          = name,
     version                       = version_ns['__version__'],
-    scripts                       = glob(pjoin('scripts', '*')),
     packages                      = packages,
     package_data                  = package_data,
     description                   = "Jupyter Qt console",


### PR DESCRIPTION
Remove the explicit "jupyter-qtconsole" script that is also covered
by an entry point.  Having both is redundant and causes "installer"
to fail on the resulting wheel.  Furthermore, installing explicit
scripts is deprecated in setuptools in favor of entry points.

Fixes #529 