### PR TITLE
Replace _get_block_plain_text() with QTextBlock.text() to fix segfault on Qt 6

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1692,15 +1692,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         return columnize(items, separator, displaywidth)
 
-    def _get_block_plain_text(self, block):
-        """ Given a QTextBlock, return its unformatted text.
-        """
-        cursor = QtGui.QTextCursor(block)
-        cursor.movePosition(QtGui.QTextCursor.StartOfBlock)
-        cursor.movePosition(QtGui.QTextCursor.EndOfBlock,
-                            QtGui.QTextCursor.KeepAnchor)
-        return cursor.selection().toPlainText()
-
     def _get_cursor(self):
         """ Get a cursor at the current insert position.
         """
@@ -1768,7 +1759,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             return None
         else:
             cursor = self._control.textCursor()
-            text = self._get_block_plain_text(cursor.block())
+            text = cursor.block().text()
             return text[len(prompt):]
 
     def _get_input_buffer_cursor_pos(self):

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -68,7 +68,6 @@ class FrontendHighlighter(PygmentsHighlighter):
         # the string as plain text so we can compare it.
         current_block = self.currentBlock()
         string = current_block.text()
-        # string = self._frontend._get_block_plain_text(current_block)
 
         # Only highlight if we can identify a prompt, but make sure not to
         # highlight the prompt.

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -67,7 +67,8 @@ class FrontendHighlighter(PygmentsHighlighter):
         # paragraph break characters, non-breaking spaces, etc. Here we acquire
         # the string as plain text so we can compare it.
         current_block = self.currentBlock()
-        string = self._frontend._get_block_plain_text(current_block)
+        string = current_block.text()
+        # string = self._frontend._get_block_plain_text(current_block)
 
         # Only highlight if we can identify a prompt, but make sure not to
         # highlight the prompt.


### PR DESCRIPTION
Replace `_get_block_plain_text()` with `QTextBlock.text()`.

Fixes #531.