### PR TITLE
Fix missing argument error when switching syntax highlighting styles on PySide2 & PySide6

### DIFF
--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -6,6 +6,7 @@ common actions.
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from functools import partial
 import sys
 import webbrowser
 from threading import Thread
@@ -625,11 +626,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.syntax_style_menu = self.view_menu.addMenu("&Syntax Style")
             style_group = QtWidgets.QActionGroup(self)
             for style in available_syntax_styles:
-                action = QtWidgets.QAction("{}".format(style), self,
-                                       triggered=lambda v,
-                                       syntax_style=style:
-                                           self.set_syntax_style(
-                                                   syntax_style=syntax_style))
+                action = QtWidgets.QAction("{}".format(style), self)
+                action.triggered.connect(partial(self.set_syntax_style,
+                                                 style))
                 action.setCheckable(True)
                 style_group.addAction(action)
                 self.syntax_style_menu.addAction(action)

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -6,9 +6,9 @@ common actions.
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from functools import partial
 import sys
 import webbrowser
+from functools import partial
 from threading import Thread
 
 from jupyter_core.paths import jupyter_runtime_dir


### PR DESCRIPTION
Replace `lambda` in syntax highlighting style `QAction` with partial objects in `init_view_menu()` for compatibility with PySide2 and Pyside6 (without breaking compatibility with PyQt5 and PyQt6).

Fixes #537.