### PR TITLE
Fix test_other_output for Qt 6.3

### DIFF
--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -74,11 +74,12 @@ class TestJupyterWidget(unittest.TestCase):
         ))
 
         # Check proper syntax highlighting
-        if QT6 and parse(QT_VERSION) < parse('6.3'):
+        if QT6 and parse(QT_VERSION) >= parse('6.3'):
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
                 'p, li { white-space: pre-wrap; }\n'
+                'hr { height: 1px; border-width: 0; }\n'
                 '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
                 '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
@@ -87,12 +88,11 @@ class TestJupyterWidget(unittest.TestCase):
                 '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:700; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
             )
-        elif QT6 and parse(QT_VERSION) >= parse('6.3'):
+        elif QT6 and parse(QT_VERSION) < parse('6.3'):
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
                 'p, li { white-space: pre-wrap; }\n'
-                'hr { height: 1px; border-width: 0; }\n'
                 '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
                 '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -1,8 +1,9 @@
 import unittest
 import sys
+from packaging.version import parse
 
 import pytest
-from qtpy import PYQT6, PYSIDE6
+from qtpy import QT6, QT_VERSION
 from qtpy import QtWidgets, QtGui
 from qtpy.QtTest import QTest
 
@@ -73,7 +74,7 @@ class TestJupyterWidget(unittest.TestCase):
         ))
 
         # Check proper syntax highlighting
-        if PYSIDE6:
+        if QT6 and parse(QT_VERSION) < parse('6.3'):
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
@@ -86,7 +87,7 @@ class TestJupyterWidget(unittest.TestCase):
                 '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:700; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
             )
-        elif PYQT6:
+        elif QT6 and parse(QT_VERSION) >= parse('6.3'):
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 
 import pytest
-from qtpy import QT6
+from qtpy import PYQT6, PYSIDE6
 from qtpy import QtWidgets, QtGui
 from qtpy.QtTest import QTest
 
@@ -52,14 +52,15 @@ class TestJupyterWidget(unittest.TestCase):
         w._show_interpreter_prompt(1)
         w.other_output_prefix = '[other] '
         w.syntax_style = 'default'
-        control = w._control
-        document = control.document()
 
         msg = dict(
             execution_count=1,
             code='a = 1 + 1\nb = range(10)',
         )
         w._append_custom(w._insert_other_input, msg, before_prompt=True)
+
+        control = w._control
+        document = control.document()
 
         self.assertEqual(document.blockCount(), 6)
         self.assertEqual(document.toPlainText(), (
@@ -72,11 +73,25 @@ class TestJupyterWidget(unittest.TestCase):
         ))
 
         # Check proper syntax highlighting
-        if QT6:
+        if PYSIDE6:
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
                 'p, li { white-space: pre-wrap; }\n'
+                '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
+                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:700; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
+                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:700; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
+            )
+        elif PYQT6:
+            html = (
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
+                '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
+                'p, li { white-space: pre-wrap; }\n'
+                'hr { height: 1px; border-width: 0; }\n'
                 '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
                 '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'


### PR DESCRIPTION
@ccordoba12 I found the reasons why `test_other_output()` is failing under Qt6:

- The existing expected `toHtml()` output seems to be written for Qt <6.3. HTML output from Qt 6.3 also adds a style definition for `hr` (even though no `hr` tags are actually used). I have added the Qt 6.3 expected HTML and modified environment detection conditions so that the test can be run under versions both above and below 6.3. Let me know if the test should only expect to be run with Qt >=6.3 and the expected output for <6.3 should be dumped. Note that nothing about the actual output has been changed.
- `document` also sometimes gets garbage collected before the assertions are run, resulting in exceptions from Qt. I have pushed the variable assignments as late as possible to avoid this.

Let me know if you have any comments.