### PR TITLE
Don't call processEvents when showing input prompts on Mac

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -63,7 +63,7 @@ jobs:
           pip list
       - name: Run tests
         shell: bash -l {0}
-        run: xvfb-run --auto-servernum pytest -x -vv -s --full-trace --cov=qtconsole qtconsole
+        run: xvfb-run --auto-servernum pytest -x -vv -s --full-trace --color=yes --cov=qtconsole qtconsole
         env:
           QT_API: ${{ matrix.QT_LIB }}
           PYTEST_QT_API: ${{ matrix.QT_LIB }}

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -44,7 +44,4 @@ jobs:
           conda list
       - name: Run tests
         shell: bash -l {0}
-        run: |
-          # Disable tests for now because they hang completely
-          # pytest -x -vv --cov=qtconsole qtconsole
-          exit 0
+        run: pytest -x -vv --cov=qtconsole qtconsole

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -44,4 +44,4 @@ jobs:
           conda list
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -x -vv --cov=qtconsole qtconsole
+        run: pytest -x -vv --color=yes --cov=qtconsole qtconsole

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -44,4 +44,4 @@ jobs:
           conda list
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -x -vv --cov=qtconsole qtconsole
+        run: pytest -x -vv --color=yes --cov=qtconsole qtconsole

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2483,7 +2483,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # This is necessary to solve out-of-order insertion of mixed stdin and
         # stdout stream texts.
         # Fixes spyder-ide/spyder#17710
-        QtCore.QCoreApplication.processEvents()
+        if not sys.platform == 'darwin':
+            QtCore.QCoreApplication.processEvents()
 
         cursor = self._get_end_cursor()
 


### PR DESCRIPTION
- That's not necessary on that platform
- It also fixes our test suite hanging for Mac on CIs.