### PR TITLE
Pinning qtpy version to 5.12.3 as a required package for installation…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup_args = dict(
         'jupyter_client>=4.1',
         'pygments',
         'ipykernel>=4.1', # not a real dependency, but require the reference kernel
-        'qtpy>=2.0.1',
+        'qtpy==5.12.3',
         'pyzmq>=17.1'
     ],
     extras_require = {


### PR DESCRIPTION
… of qtconsole

When a version of qtpy>5.12.3 installed as a dependency of qtconsole
qtpy bring in a package named libdb which is under the AGPL license,
which is a restricted license without a purchased commercial license.

```
sh-4.2$ conda-tree whoneeds -t libdb
libdb==6.2.32
  └─ jack 1.9.18 [required: >=6.2.32,<6.3.0a0]
     └─ pulseaudio 14.0 [required: >=1.9.18,<1.10.0a0]
        └─ qt-main 5.15.4 [required: >=14.0,<14.1.0a0]
           └─ pyqt 5.15.7 [required: >=5.15.4,<5.16.0a0]
              └─ qtconsole 5.3.1 [required: any]
                 └─ jupyter 1.0.0 [required: any]
                    └─ hdijupyterutils 0.20.0 [required: >=1]
                       ├─ sparkmagic 0.20.0 [required: >=0.6]
                       └─ autovizwidget 0.20.0 [required: >=0.6]
                          └─ sparkmagic 0.20.0 [required: >=0.6]
```