### PR TITLE
Drop LooseVersion in favor of QVersionNumber

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -7,7 +7,6 @@ input, there is no real readline support, among other limitations.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from distutils.version import LooseVersion
 import os
 import signal
 import sys
@@ -416,8 +415,11 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         # Fixes launching issues with Big Sur
         # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
-        if sys.platform == 'darwin' and LooseVersion(QT_VERSION) < LooseVersion('5.15.2'):
-            os.environ['QT_MAC_WANTS_LAYER'] = '1'
+        if sys.platform == 'darwin':
+            v_5_15_2 = QtCore.QVersionNumber.fromString('5.15.2')[0]
+            v_current = QtCore.QVersionNumber.fromString(QT_VERSION)[0]
+            if v_current < v_5_15_2:
+                os.environ['QT_MAC_WANTS_LAYER'] = '1'
         self._init_asyncio_patch()
         self.init_qt_app()
         super().initialize(argv)


### PR DESCRIPTION
`LooseVersion` is deprecated. One way to avoid having to depend on 3rd party packages to check version numbers is to use Qt functions.

fixes #556 