### PR TITLE
Avoid using PyQt 6.4.0 to run our tests

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -54,7 +54,11 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e .[test]
-          pip install ${{ matrix.QT_LIB }} coveralls pytest-cov
+          if [ ${{ matrix.QT_LIB }} = "pyqt6" ]; then
+            pip install pyqt6!=6.4.0 pyqt6-qt6!=6.4.0 coveralls pytest-cov
+          else
+            pip install ${{ matrix.QT_LIB }} coveralls pytest-cov
+          fi
       - name: Show environment information
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This is because that version has a bug in QTextEdit (https://bugreports.qt.io/browse/QTBUG-107004), which should be solved in 6.4.1