### PR TITLE
Call processEvents when showing input prompts on Mac but not on tests

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: True
+      QTCONSOLE_TESTING: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
       COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: macos-latest
     env:
       CI: True
+      QTCONSOLE_TESTING: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'macos'
     strategy:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: windows-latest
     env:
       CI: True
+      QTCONSOLE_TESTING: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'windows'
     strategy:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2493,7 +2493,13 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # This is necessary to solve out-of-order insertion of mixed stdin and
         # stdout stream texts.
         # Fixes spyder-ide/spyder#17710
-        if not sys.platform == 'darwin':
+        if sys.platform == 'darwin':
+            # Although this makes our tests hang on Mac, users confirmed that
+            # it's needed on that platform too.
+            # Fixes spyder-ide/spyder#19888
+            if not os.environ.get('QTCONSOLE_TESTING'):
+                QtCore.QCoreApplication.processEvents()
+        else:
             QtCore.QCoreApplication.processEvents()
 
         cursor = self._get_end_cursor()


### PR DESCRIPTION
Addresses spyder-ide/spyder#19888.