### PR TITLE
Remove usage of `QVersionNumber` because it doesn't work as expected in PySide6

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -10,9 +10,9 @@ input, there is no real readline support, among other limitations.
 import os
 import signal
 import sys
-from packaging.version import parse
 from warnings import warn
 
+from packaging.version import parse
 # If run on Windows:
 #
 # 1. Install an exception hook which pops up a message box.

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -10,7 +10,7 @@ input, there is no real readline support, among other limitations.
 import os
 import signal
 import sys
-from packaging import parse
+from packaging.version import parse
 from warnings import warn
 
 # If run on Windows:

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -13,6 +13,7 @@ import sys
 from warnings import warn
 
 from packaging.version import parse
+
 # If run on Windows:
 #
 # 1. Install an exception hook which pops up a message box.

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -57,7 +57,7 @@ if os.name == 'nt':
     except AttributeError:
         pass
 
-from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION
+from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION, QT6
 
 from traitlets.config.application import boolean_flag
 from traitlets.config.application import catch_config_error
@@ -415,7 +415,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         # Fixes launching issues with Big Sur
         # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin' and not QT6:
             v_5_15_2 = QtCore.QVersionNumber.fromString('5.15.2')[0]
             v_current = QtCore.QVersionNumber.fromString(QT_VERSION)[0]
             if v_current < v_5_15_2:

--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -10,6 +10,7 @@ input, there is no real readline support, among other limitations.
 import os
 import signal
 import sys
+from packaging import parse
 from warnings import warn
 
 # If run on Windows:
@@ -57,7 +58,7 @@ if os.name == 'nt':
     except AttributeError:
         pass
 
-from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION, QT6
+from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION
 
 from traitlets.config.application import boolean_flag
 from traitlets.config.application import catch_config_error
@@ -415,9 +416,9 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         # Fixes launching issues with Big Sur
         # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
-        if sys.platform == 'darwin' and not QT6:
-            v_5_15_2 = QtCore.QVersionNumber.fromString('5.15.2')[0]
-            v_current = QtCore.QVersionNumber.fromString(QT_VERSION)[0]
+        if sys.platform == 'darwin':
+            v_5_15_2 = parse('5.15.2')
+            v_current = parse(QT_VERSION)
             if v_current < v_5_15_2:
                 os.environ['QT_MAC_WANTS_LAYER'] = '1'
         self._init_asyncio_patch()

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup_args = dict(
         'pygments',
         'ipykernel>=4.1', # not a real dependency, but require the reference kernel
         'qtpy>=2.0.1',
-        'pyzmq>=17.1'
+        'pyzmq>=17.1',
+        'packaging'
     ],
     extras_require = {
         'test': ['flaky', 'pytest', 'pytest-qt'],


### PR DESCRIPTION
This PR closes #567 
If using pyside6 backend, `QVersionNumber.fromString('5.15.2')` returns a `PySide6.QtCore.QVersionNumber` and as a result it is not subscriptable, so launching the console results in a `TypeError`.
Because the code refers to Qt5 versions, I've added a check that the backend isn't Qt6 prior to the version checking.
On my mac this console now works in pyside6 6.4.2, though there is a warning:
```
python3.10/site-packages/jupyter_client/threaded.py:73: RuntimeWarning: ZMQStream only supports the base zmq.Socket class.

                Use zmq.Socket(shadow=other_socket)
                or `ctx.socket(zmq.SUB, socket_class=zmq.Socket)`
                to create a base zmq.Socket object,
                no matter what other kind of socket your Context creates.
                
  self.stream = zmqstream.ZMQStream(self.socket, self.ioloop)
```
I think that is unrelated to this PR and probably requires another fix.