### PR TITLE
Fix kernel autorestart after it's killed for Jupyter-client 8+

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -837,8 +837,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         # Calculate where the cursor should be *after* the change:
         position += added
-
-        document = self._control.document()
         if position == self._get_cursor().position():
             self._auto_call_tip()
 

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -538,6 +538,12 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.warning("kernel restarted")
         self._kernel_restarted_message(died=died)
+
+        # This resets the autorestart counter so that the kernel can be
+        # auto-restarted before the next time it's polled to see if it's alive.
+        if self.kernel_manager:
+            self.kernel_manager.reset_autorestart_count()
+
         self.reset()
 
     def _handle_inspect_reply(self, rep):

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -7,12 +7,9 @@ This supports the additional functionality provided by Jupyter kernel.
 # Distributed under the terms of the Modified BSD License.
 
 from collections import namedtuple
-import os.path
-import re
 from subprocess import Popen
 import sys
 import time
-from textwrap import dedent
 from warnings import warn
 
 from qtpy import QtCore, QtGui
@@ -287,7 +284,6 @@ class JupyterWidget(IPythonWidget):
         if self.include_output(msg):
             self.flush_clearoutput()
             data = msg['content']['data']
-            metadata = msg['content']['metadata']
             # In the regular JupyterWidget, we simply print the plain text
             # representation.
             if 'text/plain' in data:

--- a/qtconsole/manager.py
+++ b/qtconsole/manager.py
@@ -26,6 +26,9 @@ class QtKernelRestarter(KernelRestarter, QtKernelRestarterMixin):
     def poll(self):
         super().poll()
 
+    def reset_count(self):
+        self._restart_count = 0
+
 
 class QtKernelManager(KernelManager, QtKernelManagerMixin):
     """A KernelManager with Qt signals for restart"""
@@ -61,6 +64,11 @@ class QtKernelManager(KernelManager, QtKernelManagerMixin):
         if self._is_restarting:
             self.kernel_restarted.emit()
             self._is_restarting = False
+
+    def reset_autorestart_count(self):
+        """Reset autorestart count."""
+        if self._restarter:
+            self._restarter.reset_count()
 
     async def _async_post_start_kernel(self, **kw):
         """

--- a/qtconsole/manager.py
+++ b/qtconsole/manager.py
@@ -62,6 +62,16 @@ class QtKernelManager(KernelManager, QtKernelManagerMixin):
             self.kernel_restarted.emit()
             self._is_restarting = False
 
+    async def _async_post_start_kernel(self, **kw):
+        """
+        This is necessary for Jupyter-client 8+ because `start_kernel` doesn't
+        call `post_start_kernel` directly.
+        """
+        await super()._async_post_start_kernel(**kw)
+        if self._is_restarting:
+            self.kernel_restarted.emit()
+            self._is_restarting = False
+
     def _handle_kernel_restarting(self):
         """Kernel has died, and will be restarted."""
         self._is_restarting = True

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import sys
 
@@ -257,6 +258,49 @@ while user_input != '':
         "Write input: \nInput was entered!\n"
     )
     assert output in control.toPlainText()
+
+
+@flaky(max_runs=5)
+@pytest.mark.skipif(os.name == 'nt', reason="no SIGTERM on Windows")
+def test_restart_after_kill(qtconsole, qtbot):
+    """
+    Test that the kernel correctly restarts after a kill.
+    """
+    window = qtconsole.window
+    shell = window.active_frontend
+    control = shell._control
+
+    def wait_for_restart():
+        qtbot.waitUntil(
+            lambda: 'Kernel died, restarting' in control.toPlainText()
+        )
+
+    # Wait until the console is fully up
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # This checks that we are able to restart the kernel even after the number
+    # of consecutive auto-restarts is reached (which by default is five).
+    for _ in range(10):
+        # Clear console
+        with qtbot.waitSignal(shell.executed):
+            shell.execute('%clear')
+        qtbot.wait(500)
+
+        # Run some code that kills the kernel
+        code = "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"
+        shell.execute(code)
+
+        # Check that the restart message is printed
+        qtbot.waitUntil(
+            lambda: 'Kernel died, restarting' in control.toPlainText()
+        )
+
+        # Check that a new prompt is available after the restart
+        qtbot.waitUntil(
+            lambda: control.toPlainText().splitlines()[-1] == 'In [1]: '
+        )
+        qtbot.wait(500)
 
 
 @pytest.mark.skipif(no_display, reason="Doesn't work without a display")


### PR DESCRIPTION
Also, remove some unnecessary imports and variables.