### PR TITLE
Add missing `closed` method to `QtInProcessChannel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__
 .#*
 .coverage
 .pytest_cache
+.vscode

--- a/qtconsole/inprocess.py
+++ b/qtconsole/inprocess.py
@@ -56,6 +56,10 @@ class QtInProcessChannel(SuperQObject, InProcessChannel):
         super().flush()
         self.process_events()
 
+    def closed(self):
+        """ Function to ensure compatibility with the QtZMQSocketChannel."""
+        return False
+
 
 class QtInProcessHBChannel(SuperQObject, InProcessHBChannel):
     # This signal will never be fired, but it needs to exist

--- a/qtconsole/tests/test_inprocess_kernel.py
+++ b/qtconsole/tests/test_inprocess_kernel.py
@@ -1,0 +1,31 @@
+"""Test QtInProcessKernel"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import unittest
+
+from qtconsole.inprocess import QtInProcessKernelManager
+
+
+class InProcessTests(unittest.TestCase):
+
+    def setUp(self):
+        """Open an in-process kernel."""
+        self.kernel_manager = QtInProcessKernelManager()
+        self.kernel_manager.start_kernel()
+        self.kernel_client = self.kernel_manager.client()
+
+    def tearDown(self):
+        """Shutdown the in-process kernel. """
+        self.kernel_client.stop_channels()
+        self.kernel_manager.shutdown_kernel()
+
+    def test_execute(self):
+        """Test execution of shell commands."""
+        # check that closed works as expected
+        assert not self.kernel_client.iopub_channel.closed()
+        
+        # check that running code works
+        self.kernel_client.execute('a=1')
+        assert self.kernel_manager.kernel.shell.user_ns.get('a') == 1


### PR DESCRIPTION
In PR #574, a new function, `closed()` was added to the `QtZMQSocketChannel` class in order to check whether a channel was closed before flushing the stream. This must also be added to the `QtInProcessChannel` to ensure compatibility. Since in-process channels are never closed, this function should always return the value `False`.

This PR corrects the NeXpy issue [#378](https://github.com/nexpy/nexpy/issues/398) using the latest development version of qtconsole.