### PR TITLE
Implement .closed() for QtInProcessChannel

### DIFF
--- a/qtconsole/inprocess.py
+++ b/qtconsole/inprocess.py
@@ -45,6 +45,10 @@ class QtInProcessChannel(SuperQObject, InProcessChannel):
     def call_handlers(self, msg):
         self.message_received.emit(msg)
 
+    def closed(self):
+        """Check if the channel is closed."""
+        return not super().is_alive()
+
     def process_events(self):
         """ Process any pending GUI events.
         """


### PR DESCRIPTION
Possible fix for #576, this implements a .closed() for QtInProcessChannel. Another possible fix that might be more universal would be to instead check if iopub_channel has a closed attribute.