### PR TITLE
Check for kernel manager in case we are dealing with an externally launched kernel

### DIFF
--- a/qtconsole/qtconsoleapp.py
+++ b/qtconsole/qtconsoleapp.py
@@ -191,7 +191,7 @@ class JupyterQtConsoleApp(JupyterApp, JupyterConsoleApp):
         # start the kernel
         kwargs = {}
         # FIXME: remove special treatment of IPython kernels
-        if self.kernel_manager.ipykernel:
+        if self.kernel_manager and self.kernel_manager.ipykernel:
             kwargs['extra_arguments'] = self.kernel_argv
         kernel_manager.start_kernel(**kwargs)
         kernel_manager.client_factory = self.kernel_client_class


### PR DESCRIPTION
Fix #594. It looks like `self.kernel_argv` would be empty anyway if the kernel was launched externally.