### PR TITLE
Use string representation for QKeySequence construction

### DIFF
--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -189,9 +189,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         # Configure actions.
         action = self._copy_raw_action
-        key = QtCore.Qt.CTRL | QtCore.Qt.SHIFT | QtCore.Qt.Key_C
         action.setEnabled(False)
-        action.setShortcut(QtGui.QKeySequence(key))
+        action.setShortcut(QtGui.QKeySequence("Ctrl+Shift+C"))
         action.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
         action.triggered.connect(self.copy_raw)
         self.copy_available.connect(action.setEnabled)


### PR DESCRIPTION
This fixes an issue in PySide6 v6.6.2 where key sequence construction with the | operator is broken, and improves readability. 
Ideally this would be fixed in PySide6 or qtpy to retain original behavior, but since it also improves readability I think it makes sense to fix it here too.

Broken with PySide6 v6.6.2:

```py
from qtpy import QtCore
QtCore.Qt.AltModifier | QtCore.Qt.Key.Key_C
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 QtCore.Qt.AltModifier | QtCore.Qt.Key.Key_C

TypeError: unsupported operand type(s) for |: 'KeyboardModifier' and 'Key'
```
