### PR TITLE
Use new format for instersphinx_mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -312,4 +312,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}


### PR DESCRIPTION
The current format is deprecated since sphinx 6.2 and will be removed in the future.