### PR TITLE
Fix running workflows in the `main` branch

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -3,10 +3,10 @@ name: Linux tests
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -3,10 +3,10 @@ name: Macos tests
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 concurrency:
   group: macos-tests-${{ github.ref }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -3,10 +3,10 @@ name: Windows tests
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 concurrency:
   group: windows-tests-${{ github.ref }}


### PR DESCRIPTION
- Our workflows are not running when PRs are merged to `main` because they are still targeting `master`.
- This should also fix updating our docs in Read the docs.