### PR TITLE
Fix Carriage Return Handling in QtConsole

### DIFF
--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2519,6 +2519,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         cursor = self._get_end_cursor()
 
+        # Memorize end to check if we actually add any prompt characters
+        prior_end_pos = cursor.position()
+
         # Save the current position to support _append*(before_prompt=True).
         # We can't leave the cursor at the end of the document though, because
         # that would cause any further additions to move the cursor. Therefore,
@@ -2557,7 +2560,16 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 self._prompt_html = None
 
         self._flush_pending_stream()
-        self._prompt_cursor.setPosition(self._get_end_pos() - 1)
+
+        current_end_pos = self._get_end_pos()
+        if prior_end_pos != current_end_pos:
+            # Set the prompt cursor to end minus 1, so long as
+            # the prompt was not blank
+            self._prompt_cursor.setPosition(current_end_pos - 1)
+        else:
+            # The prompt didn't move end, i.e. the prompt inserted exactly 0 characters
+            # Move cursor to end
+            self._prompt_cursor.setPosition(current_end_pos)
 
         if move_forward:
             self._append_before_prompt_cursor.setPosition(

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2519,9 +2519,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         cursor = self._get_end_cursor()
 
-        # Memorize end to check if we actually add any prompt characters
-        prior_end_pos = cursor.position()
-
         # Save the current position to support _append*(before_prompt=True).
         # We can't leave the cursor at the end of the document though, because
         # that would cause any further additions to move the cursor. Therefore,
@@ -2560,16 +2557,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                 self._prompt_html = None
 
         self._flush_pending_stream()
-
-        current_end_pos = self._get_end_pos()
-        if prior_end_pos != current_end_pos:
-            # Set the prompt cursor to end minus 1, so long as
-            # the prompt was not blank
-            self._prompt_cursor.setPosition(current_end_pos - 1)
-        else:
-            # The prompt didn't move end, i.e. the prompt inserted exactly 0 characters
-            # Move cursor to end
-            self._prompt_cursor.setPosition(current_end_pos)
+        self._prompt_cursor.setPosition(self._get_end_pos() - 1)
 
         if move_forward:
             self._append_before_prompt_cursor.setPosition(

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1028,7 +1028,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             # Insert at current printing point
             # If cursor is before prompt jump to end, but only if there
             # is a prompt (before_prompt_pos != end)
-            if cursor.position() < self._append_before_prompt_pos \
+            if cursor.position() <= self._append_before_prompt_pos \
                     and self._append_before_prompt_pos != self._get_end_pos():
                 cursor.movePosition(QtGui.QTextCursor.End)
 
@@ -2562,6 +2562,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         if move_forward:
             self._append_before_prompt_cursor.setPosition(
                 self._append_before_prompt_cursor.position() + 1)
+        else:
+            # cursor position was 0, set before prompt cursor
+            self._append_before_prompt_cursor.setPosition(0)
         self._prompt_started()
 
     #------ Signal handlers ----------------------------------------------------

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -1006,7 +1006,6 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         else:
             if insert != self._insert_plain_text:
                 self._flush_pending_stream()
-            cursor.movePosition(QtGui.QTextCursor.End)
 
         # Perform the insertion.
         result = insert(cursor, input, *args, **kwargs)
@@ -1660,10 +1659,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         """ Flush the pending stream output and change the
         prompt position appropriately.
         """
-        cursor = self._control.textCursor()
-        cursor.movePosition(QtGui.QTextCursor.End)
         self._flush_pending_stream()
-        cursor.movePosition(QtGui.QTextCursor.End)
 
     def _flush_pending_stream(self):
         """ Flush out pending text into the widget. """
@@ -1674,7 +1670,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
             text = self._get_last_lines_from_list(text, buffer_size)
         text = ''.join(text)
         t = time.time()
-        self._insert_plain_text(self._get_end_cursor(), text, flush=True)
+        self._insert_plain_text(self._control.textCursor(), text, flush=True)
         # Set the flush interval to equal the maximum time to update text.
         self._pending_text_flush_interval.setInterval(
             int(max(100, (time.time() - t) * 1000))
@@ -2123,7 +2119,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                             cursor.select(QtGui.QTextCursor.Document)
                             remove = True
                         if act.area == 'line':
-                            if act.erase_to == 'all': 
+                            if act.erase_to == 'all':
                                 cursor.select(QtGui.QTextCursor.LineUnderCursor)
                                 remove = True
                             elif act.erase_to == 'start':
@@ -2137,7 +2133,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                                     QtGui.QTextCursor.EndOfLine,
                                     QtGui.QTextCursor.KeepAnchor)
                                 remove = True
-                        if remove: 
+                        if remove:
                             nspace=cursor.selectionEnd()-cursor.selectionStart() if fill else 0
                             cursor.removeSelectedText()
                             if nspace>0: cursor.insertText(' '*nspace) # replace text by space, to keep cursor position as specified
@@ -2181,11 +2177,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                         remain = cursor2.position() - pos    # number of characters until end of line
                         n=len(substring)
                         swallow = min(n, remain)             # number of character to swallow
-                        cursor.setPosition(pos+swallow,QtGui.QTextCursor.KeepAnchor)
+                        cursor.setPosition(pos + swallow, QtGui.QTextCursor.KeepAnchor)
                     cursor.insertText(substring,format)
         else:
             cursor.insertText(text)
         cursor.endEditBlock()
+        self._control.setTextCursor(cursor)
 
         if should_autoscroll:
             self._scroll_to_end()

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -851,12 +851,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
             self._insert_plain_text_into_buffer(cursor, dedent(text))
 
-    def print_(self, printer = None):
+    def print_(self, printer=None):
         """ Print the contents of the ConsoleWidget to the specified QPrinter.
         """
-        if (not printer):
+        if not printer:
             printer = QtPrintSupport.QPrinter()
-            if(QtPrintSupport.QPrintDialog(printer).exec_() != QtPrintSupport.QPrintDialog.Accepted):
+            if QtPrintSupport.QPrintDialog(printer).exec_() != QtPrintSupport.QPrintDialog.Accepted:
                 return
         self._control.print_(printer)
 
@@ -1039,7 +1039,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         result = insert(cursor, input, *args, **kwargs)
 
         # Remove insert mode tag
-        if hasattr(cursor, "_insert_mode"):
+        if hasattr(cursor, '_insert_mode'):
             del cursor._insert_mode
 
         return result
@@ -1077,7 +1077,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         # Select and remove all text below the input buffer.
         cursor = self._get_prompt_cursor()
         prompt = self._continuation_prompt.lstrip()
-        if(self._temp_buffer_filled):
+        if self._temp_buffer_filled:
             self._temp_buffer_filled = False
             while cursor.movePosition(QtGui.QTextCursor.NextBlock):
                 temp_cursor = QtGui.QTextCursor(cursor)
@@ -1689,13 +1689,15 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
         return False
 
     def _on_flush_pending_stream_timer(self):
-        """ Flush the pending stream output and change the
-        prompt position appropriately.
+        """ Flush pending text into the widget on console timer trigger.
         """
         self._flush_pending_stream()
 
     def _flush_pending_stream(self):
-        """ Flush out pending text into the widget. """
+        """ Flush pending text into the widget. Only applies to text that is pending
+            when the console is in the running state. Text printed when console is
+            not running is shown immediately, and does not wait to be flushed.
+        """
         text = self._pending_insert_text
         self._pending_insert_text = []
         buffer_size = self._control.document().maximumBlockCount()
@@ -2430,7 +2432,7 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
         self._reading = True
         if password:
-            self._show_prompt('Warning: QtConsole does not support password mode, '\
+            self._show_prompt('Warning: QtConsole does not support password mode, '
                               'the text you type will be visible.', newline=True)
 
         if 'ipdb' not in prompt.lower():

--- a/qtconsole/frontend_widget.py
+++ b/qtconsole/frontend_widget.py
@@ -728,7 +728,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
     def append_stream(self, text):
         """Appends text to the output stream."""
-        self._append_plain_text(text, before_prompt=True)
+        self._append_plain_text(text, before_prompt = True)
 
     def flush_clearoutput(self):
         """If a clearoutput is pending, execute it."""

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -491,15 +491,6 @@ class TestConsoleWidget(unittest.TestCase):
         self.assertEqual(w._append_before_prompt_pos,
                          w._prompt_pos - len(w._prompt))
 
-        # Test a blank prompt. Such as from input()
-        w._append_plain_text('\n')
-        w._show_prompt(prompt = '', separator = False)
-
-        w._append_plain_text('plain text\n')
-
-        self.assertEqual(w._prompt_pos, w._get_end_pos())
-        self.assertEqual(w._append_before_prompt_pos, w._prompt_pos)
-
     def test_select_all(self):
         w = ConsoleWidget()
         w._append_plain_text('Header\n')

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -371,7 +371,7 @@ class TestConsoleWidget(unittest.TestCase):
             # clear all the text
             cursor.insertText('')
 
-    def test_carriage_return(self):
+    def test_print_while_executing(self):
         """ Does overwriting the currentt line with carriage return work?
         """
         w = ConsoleWidget()
@@ -386,6 +386,27 @@ class TestConsoleWidget(unittest.TestCase):
         expected_output = "Hello\u20290123456789\u2029"
 
         w._executing = True
+        for text in test_inputs:
+            w._append_plain_text(text, before_prompt = True)
+            w._flush_pending_stream() # emulate text being flushed
+
+        cursor = w._get_cursor()
+        self.assert_text_equal(cursor, expected_output)
+
+    def test_print_while_reading(self):
+        """ Does overwriting the currentt line with carriage return work?
+        """
+        w = ConsoleWidget()
+        test_inputs = ['Hello\n',
+                       'World\r',
+                       '*' * 10,
+                       '\r',
+                       '0', '1', '2', '3', '4',
+                       '5', '6', '7', '8', '9',
+                       '\r\n']
+
+        expected_output = "Hello\u20290123456789\u2029"
+
         for text in test_inputs:
             w._append_plain_text(text, before_prompt = True)
             w._flush_pending_stream() # emulate text being flushed

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -375,21 +375,22 @@ class TestConsoleWidget(unittest.TestCase):
         """ Does overwriting the currentt line with carriage return work?
         """
         w = ConsoleWidget()
-        test_inputs = ['Hello\n'
+        test_inputs = ['Hello\n',
                        'World\r',
                        '*' * 10,
-                       '\r'
+                       '\r',
                        '0', '1', '2', '3', '4',
                        '5', '6', '7', '8', '9',
                        '\r\n']
 
         expected_output = "Hello\u20290123456789\u2029"
 
+        w._executing = True
         for text in test_inputs:
-            cursor = w._get_cursor()
-            w._insert_plain_text(cursor, text, flush = True)
+            w._append_plain_text(text, before_prompt = True)
             w._flush_pending_stream() # emulate text being flushed
 
+        cursor = w._get_cursor()
         self.assert_text_equal(cursor, expected_output)
 
     def test_link_handling(self):

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -491,6 +491,15 @@ class TestConsoleWidget(unittest.TestCase):
         self.assertEqual(w._append_before_prompt_pos,
                          w._prompt_pos - len(w._prompt))
 
+        # Test a blank prompt. Such as from input()
+        w._append_plain_text('\n')
+        w._show_prompt(prompt = '', separator = False)
+
+        w._append_plain_text('plain text\n')
+
+        self.assertEqual(w._prompt_pos, w._get_end_pos())
+        self.assertEqual(w._append_before_prompt_pos, w._prompt_pos)
+
     def test_select_all(self):
         w = ConsoleWidget()
         w._append_plain_text('Header\n')

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -371,6 +371,27 @@ class TestConsoleWidget(unittest.TestCase):
             # clear all the text
             cursor.insertText('')
 
+    def test_carriage_return(self):
+        """ Does overwriting the currentt line with carriage return work?
+        """
+        w = ConsoleWidget()
+        test_inputs = ['Hello\n'
+                       'World\r',
+                       '*' * 10,
+                       '\r'
+                       '0', '1', '2', '3', '4',
+                       '5', '6', '7', '8', '9',
+                       '\r\n']
+
+        expected_output = "Hello\u20290123456789\u2029"
+
+        for text in test_inputs:
+            cursor = w._get_cursor()
+            w._insert_plain_text(cursor, text, flush = True)
+            w._flush_pending_stream() # emulate text being flushed
+
+        self.assert_text_equal(cursor, expected_output)
+
     def test_link_handling(self):
         noButton = QtCore.Qt.NoButton
         noButtons = QtCore.Qt.NoButton

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -391,7 +391,7 @@ class TestConsoleWidget(unittest.TestCase):
                        '\r\n']
 
         for text in test_inputs:
-            w._append_plain_text(text, before_prompt = True)
+            w._append_plain_text(text, before_prompt=True)
             w._flush_pending_stream() # emulate text being flushed
 
         self.assert_text_equal(w._get_cursor(),
@@ -403,7 +403,7 @@ class TestConsoleWidget(unittest.TestCase):
                        '\r', 'Bar', '\n']
 
         for text in test_inputs:
-            w._append_plain_text(text, before_prompt = False)
+            w._append_plain_text(text, before_prompt=False)
             w._flush_pending_stream() # emulate text being flushed
 
         self.assert_text_equal(w._get_cursor(),
@@ -486,7 +486,7 @@ class TestConsoleWidget(unittest.TestCase):
                          w._prompt_pos - len(w._prompt))
 
         # insert some text before the prompt
-        w._append_plain_text('line', before_prompt = True)
+        w._append_plain_text('line', before_prompt=True)
         self.assertEqual(w._prompt_pos, w._get_end_pos())
         self.assertEqual(w._append_before_prompt_pos,
                          w._prompt_pos - len(w._prompt))


### PR DESCRIPTION
Fix the handling of carriage return so it is not ignored at the end of a print line.

This allows for progress bars that rely on adding a carriage return at the end of the line such as:

```python
print("Progress 55%", end = "\r")
```

tl;dr
Preserve position of cursor so ANSI commands such as \r that modify position will preserve the position they specified over multiple calls. This is particularly relevant if time passes between print calls (~100 ms).

## Explanation

First of all, when you `print()` or call `sys.stdout.write()` in QtConsole, this ultimately causes the text to be passed to the frontend widget.

https://github.com/jupyter/qtconsole/blob/56e5a5ec5cfccf5afd098fe8bb5b2c558a1dc8f9/qtconsole/frontend_widget.py#L729

This will lead to the text by passed to the console widget, which will call the ANSI Processor in:

https://github.com/jupyter/qtconsole/blob/56e5a5ec5cfccf5afd098fe8bb5b2c558a1dc8f9/qtconsole/console_widget.py#L2085

The ANSI preprocessor already handles the carriage return, so code that that uses the carriage return in the middle of a print already worked.

```
print("Hello\rWorld")
World
```

This will even work for calls from multiple prints, but this *only* works because the text is internally buffered, and recombined so `print("Hello", end = "\r"); print("World")` is all combined into the text `"Hello\rWorld" by the time `_insert_plain_text()` is called.

However, `_insert_plain_text()` and `_flush_pending_stream()` both force the cursor position to the end of the line at the end of the call. This means that a `'\r'` at the end of a line is effectively ignored, _if_ something stops the text from being combined back together, such as more than ~100 ms passing between prints.

![Time](https://github.com/jupyter/qtconsole/assets/22862051/75352661-2b28-45fb-b9a7-ec05a7e32c0b)

This PR fixes this issue by updating the cursor position to the place it was put to by `_insert_plain_text()`.

Before this gets merged, I do want to make sure there are no odd situations where the cursor now not being the end of text leads to issues.

## Behavior Change

### Before

![Before](https://github.com/jupyter/qtconsole/assets/22862051/60c2d245-2b10-4550-a7ba-5b2741070e09)

### After

![After](https://github.com/jupyter/qtconsole/assets/22862051/c61f1435-8c4c-4ce4-83d8-dce95c54e1cc)

## Notes

Related Github Issues

 - #272
 - #553 
 - https://github.com/spyder-ide/spyder/issues/195
 - https://github.com/spyder-ide/spyder/issues/20388


This does not exactly address #350, not adding support for any new ANSI codes, just fixing the existing support for `'\r'`
