### PR TITLE
Use selected syntax style for tracebacks and improve ANSI color codes support

### DIFF
--- a/qtconsole/_version.py
+++ b/qtconsole/_version.py
@@ -1,2 +1,2 @@
-version_info = (5, 6, 0, 'dev0')
+version_info = (5, 5, 2)
 __version__ = '.'.join(map(str, version_info))

--- a/qtconsole/_version.py
+++ b/qtconsole/_version.py
@@ -1,2 +1,2 @@
-version_info = (5, 5, 2)
+version_info = (5, 6, 0, 'dev0')
 __version__ = '.'.join(map(str, version_info))

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -292,6 +292,31 @@ class AnsiCodeProcessor(object):
             self.actions.append(ScrollAction('scroll', 'down', 'page', 1))
         return ''
 
+    def _parse_ansi_color(self, color, intensity):
+        """
+        Map an ANSI color code to color name or a RGB tuple.
+        Based on: https://gist.github.com/MightyPork/1d9bd3a3fd4eb1a661011560f6921b5b
+        """
+        parsed_color = None
+        if color < 8:
+            # Adjust for intensity, if possible.
+            if intensity > 0:
+                color += 8
+            parsed_color = self.color_map.get(color, None)
+        elif (color > 231):
+                s = int((color - 232) * 10 + 8)
+                parsed_color = (s, s, s)
+        else:
+            n = color - 16
+            b = n % 6
+            g = (n - b) / 6 % 6
+            r = (n - b - g * 6) / 36 % 6
+            r = int(r * 40 + 55) if r else 0
+            g = int(g * 40 + 55) if g else 0
+            b = int(b * 40 + 55) if b else 0
+            parsed_color = (r, g, b)
+        return parsed_color
+
 
 class QtAnsiCodeProcessor(AnsiCodeProcessor):
     """ Translates ANSI escape codes into QTextCharFormats.
@@ -323,12 +348,8 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
         """ Returns a QColor for a given color code or rgb list, or None if one
             cannot be constructed.
         """
-
         if isinstance(color, int):
-            # Adjust for intensity, if possible.
-            if color < 8 and intensity > 0:
-                color += 8
-            constructor = self.color_map.get(color, None)
+            constructor = self._parse_ansi_color(color, intensity)
         elif isinstance(color, (tuple, list)):
             constructor = color
         else:

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -300,7 +300,7 @@ class AnsiCodeProcessor(object):
         parsed_color = None
         if color < 16:
             # Adjust for intensity, if possible.
-            if intensity > 0:
+            if intensity > 0 and color < 8:
                 color += 8
             parsed_color = self.color_map.get(color, None)
         elif (color > 231):

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -298,7 +298,7 @@ class AnsiCodeProcessor(object):
         Based on: https://gist.github.com/MightyPork/1d9bd3a3fd4eb1a661011560f6921b5b
         """
         parsed_color = None
-        if color < 8:
+        if color < 16:
             # Adjust for intensity, if possible.
             if intensity > 0:
                 color += 8

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -810,7 +810,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.active_frontend._syntax_style_changed()
         self.active_frontend._style_sheet_changed()
         self.active_frontend.reset(clear=True)
-        self.active_frontend._execute("%colors linux", True)
         selectColor = styles.get_colors(syntax_style)
         self.active_frontend._execute("from IPython.core.ultratb import VerboseTB\n"+
                                       "VerboseTB._tb_highlight = 'bg:%(select)s'\n"%selectColor+

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -810,10 +810,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.active_frontend._syntax_style_changed()
         self.active_frontend._style_sheet_changed()
         self.active_frontend.reset(clear=True)
-        selectColor = styles.get_colors(syntax_style)
-        self.active_frontend._execute("from IPython.core.ultratb import VerboseTB\n"+
-                                      f"VerboseTB._tb_highlight = 'bg:%{selectColor}'\n"+
-                                      f"VerboseTB._tb_highlight_style = '{syntax_style}'", True)
+        self.active_frontend._execute(
+            f"from IPython.core.ultratb import VerboseTB;"
+            "VerboseTB._tb_highlight_style = '{syntax_style}'",
+            True)
         
 
     def close_active_frontend(self):

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -801,6 +801,7 @@ class MainWindow(QtWidgets.QMainWindow):
             colors='nocolor'
         elif styles.dark_style(syntax_style):
             colors='linux'
+            
         else:
             colors='lightbg'
         self.active_frontend.syntax_style = syntax_style
@@ -810,6 +811,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.active_frontend._style_sheet_changed()
         self.active_frontend.reset(clear=True)
         self.active_frontend._execute("%colors linux", True)
+        selectColor = styles.get_colors(syntax_style)
+        self.active_frontend._execute("from IPython.core.ultratb import VerboseTB\n"+
+                                      "VerboseTB._tb_highlight = 'bg:%(select)s'\n"%selectColor+
+                                      f"VerboseTB._tb_highlight_style = '{syntax_style}'", True)
+        
 
     def close_active_frontend(self):
         self.close_tab(self.active_frontend)

--- a/qtconsole/mainwindow.py
+++ b/qtconsole/mainwindow.py
@@ -812,7 +812,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.active_frontend.reset(clear=True)
         selectColor = styles.get_colors(syntax_style)
         self.active_frontend._execute("from IPython.core.ultratb import VerboseTB\n"+
-                                      "VerboseTB._tb_highlight = 'bg:%(select)s'\n"%selectColor+
+                                      f"VerboseTB._tb_highlight = 'bg:%{selectColor}'\n"+
                                       f"VerboseTB._tb_highlight_style = '{syntax_style}'", True)
         
 

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -34,7 +34,7 @@ class TestJupyterWidget(unittest.TestCase):
         w = JupyterWidget(kind='rich')
 
         # By default, the background is light. White text is rendered as black
-        self.assertEqual(w._ansi_processor.get_color(15).name(), '#000000')
+        self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')
 
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -37,7 +37,7 @@ class TestJupyterWidget(unittest.TestCase):
         self.assertEqual(w._ansi_processor.get_color(15).name(), '#000000')
 
         # Color code 40
-        self.assertEqual(w._ansi_processor.get_color(40).name(), '#37D737')
+        self.assertEqual(w._ansi_processor.get_color(40).name(), '#00d700')
         
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -36,12 +36,15 @@ class TestJupyterWidget(unittest.TestCase):
         # By default, the background is light. White text is rendered as black
         self.assertEqual(w._ansi_processor.get_color(15).name(), '#000000')
 
+        # Color code 40
+        self.assertEqual(w._ansi_processor.get_color(40).name(), '#37D737')
+        
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'
         self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')
         
-        # Color code 40
-        self.assertEqual(w._ansi_processor.get_color(40).name(), '#37D737')
+        # Color code 40 with monokai
+        self.assertEqual(w._ansi_processor.get_color(40).name(), '#00d700')
 
     @pytest.mark.skipif(not sys.platform.startswith('linux'),
                         reason="Works only on Linux")

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -34,7 +34,7 @@ class TestJupyterWidget(unittest.TestCase):
         w = JupyterWidget(kind='rich')
 
         # By default, the background is light. White text is rendered as black
-        self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')
+        self.assertEqual(w._ansi_processor.get_color(15).name(), '#000000')
 
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'

--- a/qtconsole/tests/test_jupyter_widget.py
+++ b/qtconsole/tests/test_jupyter_widget.py
@@ -39,6 +39,9 @@ class TestJupyterWidget(unittest.TestCase):
         # Change to a dark colorscheme. White text is rendered as white
         w.syntax_style = 'monokai'
         self.assertEqual(w._ansi_processor.get_color(15).name(), '#ffffff')
+        
+        # Color code 40
+        self.assertEqual(w._ansi_processor.get_color(40).name(), '#37D737')
 
     @pytest.mark.skipif(not sys.platform.startswith('linux'),
                         reason="Works only on Linux")


### PR DESCRIPTION
Fixed traceback higlight, making use of the VerboseTB hack and adding a color homologation to expand the range of colors used by QtConsole
Before:
![BeforeQtConsole](https://github.com/jupyter/qtconsole/assets/42411448/1fdc6ff5-9623-4a28-a3ac-010ec1921e59)
![BeforeQtConsolea (online-video-cutter com)](https://github.com/jupyter/qtconsole/assets/42411448/4def2a2f-604c-485b-bf73-bcc3c87547f9)

After:

![AfterQtConsole](https://github.com/jupyter/qtconsole/assets/42411448/f61e5d96-bdc8-41b8-abd7-d313cc535cc9)
![AfterQtConsolea](https://github.com/jupyter/qtconsole/assets/42411448/42345f25-5e94-4ad6-be65-1ff161ff98b8)

**related issues**
https://github.com/spyder-ide/spyder/issues/4891
