### PR TITLE
PR: Change ANSI color code 3 mapping from `brown` to `gold` and set bold format processing enabled by default

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -302,7 +302,7 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
         0  : 'black',       # black
         1  : 'darkred',     # red
         2  : 'darkgreen',   # green
-        3  : 'brown',       # yellow
+        3  : 'gold',       # yellow
         4  : 'darkblue',    # blue
         5  : 'darkviolet',  # magenta
         6  : 'steelblue',   # cyan

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -61,7 +61,7 @@ class AnsiCodeProcessor(object):
 
     # Whether to increase intensity or set boldness for SGR code 1.
     # (Different terminals handle this in different ways.)
-    bold_text_enabled = False
+    bold_text_enabled = True
 
     # We provide an empty default color map because subclasses will likely want
     # to use a custom color format.

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -37,7 +37,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
     def test_colors(self):
         """ Do basic controls sequences for colors work?
         """
-        string = 'first\x1b[34mblue\x1b[0mlast'
+        string = 'first\x1b[34mblue\x1b[0mlast\033[33mYellow'
         i = -1
         for i, substring in enumerate(self.processor.split_string(string)):
             if i == 0:
@@ -49,6 +49,9 @@ class TestAnsiCodeProcessor(unittest.TestCase):
             elif i == 2:
                 self.assertEqual(substring, 'last')
                 self.assertEqual(self.processor.foreground_color, None)
+            elif i == 3:
+                self.assertEqual(substring, 'Yellow')
+                self.assertEqual(self.processor.foreground_color, 3)
             else:
                 self.fail('Too many substrings.')
         self.assertEqual(i, 2, 'Too few substrings.')

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -2,13 +2,14 @@
 import unittest
 
 # Local imports
-from qtconsole.ansi_code_processor import AnsiCodeProcessor
+from qtconsole.ansi_code_processor import AnsiCodeProcessor, QtAnsiCodeProcessor
 
 
 class TestAnsiCodeProcessor(unittest.TestCase):
 
     def setUp(self):
         self.processor = AnsiCodeProcessor()
+        self.qt_processor = QtAnsiCodeProcessor()
 
     def test_clear(self):
         """ Do control sequences for clearing the console work?
@@ -50,8 +51,11 @@ class TestAnsiCodeProcessor(unittest.TestCase):
                 self.assertEqual(substring, 'last')
                 self.assertEqual(self.processor.foreground_color, None)
             elif i == 3:
+                foreground_color = self.processor.foreground_color
+                self.assertEqual(self.qt_processor.get_color(foreground_color).name(), '#ffd700')
                 self.assertEqual(substring, 'Yellow')
                 self.assertEqual(self.processor.foreground_color, 3)
+
             else:
                 self.fail('Too many substrings.')
         self.assertEqual(i, 2, 'Too few substrings.')


### PR DESCRIPTION
After:
![image](https://github.com/jupyter/qtconsole/assets/42411448/b1827d4c-d579-4029-8f15-fa26baf7c1e8)
Fixes #273 
Related to https://github.com/spyder-ide/spyder/issues/21225