### PR TITLE
Remove unnecessary `pyzmq` requirement

### DIFF
--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -9,7 +9,6 @@ dependencies:
 - jupyter_client
 - pygments
 - ipykernel
-- pyzmq >=17.1
 
 # For testing
 - coveralls

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup_args = dict(
         'pygments',
         'ipykernel>=4.1', # not a real dependency, but require the reference kernel
         'qtpy>=2.4.0',
-        'pyzmq>=17.1',
         'packaging'
     ],
     extras_require = {


### PR DESCRIPTION
'pyzmq' is not used in sources, which was pulled in in 79b0b02f3