### PR TITLE
Prevent debugger warning message from appearing while testing communications between kernel and frontend

### DIFF
--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -1,3 +1,4 @@
+import os
 import time
 from queue import Empty
 import unittest
@@ -11,6 +12,9 @@ class Tests(unittest.TestCase):
 
     def setUp(self):
         """Open a kernel."""
+        # Prevent tests assertions related with message type from failing
+        # due to a debug warning
+        os.environ['PYDEVD_DISABLE_FILE_VALIDATION'] = '1'
         self.kernel_manager = QtKernelManager()
         self.kernel_manager.start_kernel()
         self.kernel_client = self.kernel_manager.client()


### PR DESCRIPTION
Seems like the `test_comms` tests have been failing since when checking communications between kernel and frontend there is a possibility for a debugger warning message to appear (`Debugger warning: It seems that frozen modules are being used...`)

