### PR TITLE
Add logic to handle ANSI escape sequences to move cursor

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -147,7 +147,7 @@ class AnsiCodeProcessor(object):
 
         if last_char is not None:
             self.actions.append(NewLineAction('newline'))
-            yield last_char
+            yield None
 
     def set_csi_code(self, command, params=[]):
         """ Set attributes based on CSI (Control Sequence Introducer) code.

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -147,7 +147,7 @@ class AnsiCodeProcessor(object):
 
         if last_char is not None:
             self.actions.append(NewLineAction('newline'))
-            yield None
+            yield last_char
 
     def set_csi_code(self, command, params=[]):
         """ Set attributes based on CSI (Control Sequence Introducer) code.

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -92,9 +92,6 @@ class AnsiCodeProcessor(object):
         self.actions = []
         start = 0
 
-        # strings ending with \r are assumed to be ending in \r\n since
-        # \n is appended to output strings automatically.  Accounting
-        # for that, here.
         last_char = None
         string = string[:-1] if last_char is not None else string
 

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -95,7 +95,7 @@ class AnsiCodeProcessor(object):
         # strings ending with \r are assumed to be ending in \r\n since
         # \n is appended to output strings automatically.  Accounting
         # for that, here.
-        last_char = None#'\n' if len(string) > 0 and string[-1] == '\n' else None
+        last_char = None
         string = string[:-1] if last_char is not None else string
 
         for match in ANSI_OR_SPECIAL_PATTERN.finditer(string):

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -122,7 +122,7 @@ class AnsiCodeProcessor(object):
                 self.actions = []
             elif g0 == '\n' or g0 == '\r\n':
                 self.actions.append(NewLineAction('newline'))
-                yield g0
+                yield None
                 self.actions = []
             else:
                 params = [ param for param in groups[1].split(';') if param ]

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -190,10 +190,9 @@ class AnsiCodeProcessor(object):
             count = params[0] if params else 1
             self.actions.append(MoveAction('move', dir, 'line', count))
         elif (command == 'F'):  # Goes back to the begining of the n-th previous line
-            dir = 'up'
+            dir = 'leftup'
             count = params[0] if params else 1
             self.actions.append(MoveAction('move', dir, 'line', count))
-            self.actions.append(CarriageReturnAction('carriage-return'))
         
 
     def set_osc_code(self, params):

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -95,7 +95,7 @@ class AnsiCodeProcessor(object):
         # strings ending with \r are assumed to be ending in \r\n since
         # \n is appended to output strings automatically.  Accounting
         # for that, here.
-        last_char = '\n' if len(string) > 0 and string[-1] == '\n' else None
+        last_char = None#'\n' if len(string) > 0 and string[-1] == '\n' else None
         string = string[:-1] if last_char is not None else string
 
         for match in ANSI_OR_SPECIAL_PATTERN.finditer(string):

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -185,6 +185,17 @@ class AnsiCodeProcessor(object):
             count = params[0] if params else 1
             self.actions.append(ScrollAction('scroll', dir, 'line', count))
 
+        elif (command == 'A'):  # Move N lines Up
+            dir = 'up'
+            count = params[0] if params else 1
+            self.actions.append(MoveAction('move', dir, 'line', count))
+        elif (command == 'F'):  # Goes back to the begining of the n-th previous line
+            dir = 'up'
+            count = params[0] if params else 1
+            self.actions.append(MoveAction('move', dir, 'line', count))
+            self.actions.append(CarriageReturnAction('carriage-return'))
+        
+
     def set_osc_code(self, params):
         """ Set attributes based on OSC (Operating System Command) parameters.
 

--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -189,6 +189,10 @@ class AnsiCodeProcessor(object):
             dir = 'up'
             count = params[0] if params else 1
             self.actions.append(MoveAction('move', dir, 'line', count))
+        elif (command == 'B'):  # Move N lines Down
+            dir = 'down'
+            count = params[0] if params else 1
+            self.actions.append(MoveAction('move', dir, 'line', count))
         elif (command == 'F'):  # Goes back to the begining of the n-th previous line
             dir = 'leftup'
             count = params[0] if params else 1

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2220,13 +2220,19 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                                 QtGui.QTextCursor.MoveAnchor)
 
                     elif act.action == 'newline':
-                        self.log.debug(self._prompt)
-                        if cursor.block() != cursor.document().lastBlock():
+                        if (
+                            cursor.block() != cursor.document().lastBlock()
+                            and not cursor.document()
+                            .toPlainText()
+                            .endswith(self._prompt)
+                        ):
                             cursor.movePosition(QtGui.QTextCursor.NextBlock)
                         else:
-                            cursor.movePosition(QtGui.QTextCursor.EndOfLine,
-                                                QtGui.QTextCursor.MoveAnchor)
-                            cursor.insertText('\n')
+                            cursor.movePosition(
+                                QtGui.QTextCursor.EndOfLine,
+                                QtGui.QTextCursor.MoveAnchor,
+                            )
+                            cursor.insertText("\n")
 
                 # simulate replacement mode
                 if substring is not None:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2154,6 +2154,11 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                             cursor.select(QtGui.QTextCursor.Document)
                             cursor.removeSelectedText()
 
+                    elif act.action == 'move' and act.unit == 'line' and act.dir == 'up':
+                        for i in range(act.count):
+                            cursor.movePosition(
+                                QtGui.QTextCursor.Up)
+
                     elif act.action == 'carriage-return':
                         cursor.movePosition(
                             QtGui.QTextCursor.StartOfLine,

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2220,7 +2220,10 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                                 QtGui.QTextCursor.MoveAnchor)
 
                     elif act.action == 'newline':
-                        if not cursor.movePosition(QtGui.QTextCursor.NextBlock):
+                        self.log.debug(self._prompt)
+                        if cursor.block() != cursor.document().lastBlock():
+                            cursor.movePosition(QtGui.QTextCursor.NextBlock)
+                        else:
                             cursor.movePosition(QtGui.QTextCursor.EndOfLine,
                                                 QtGui.QTextCursor.MoveAnchor)
                             cursor.insertText('\n')

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2221,8 +2221,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
                     elif act.action == 'newline':
                         if not cursor.movePosition(QtGui.QTextCursor.NextBlock):
-                            cursor.insertText('\n')
                             cursor.movePosition(QtGui.QTextCursor.EndOfLine)
+                            cursor.insertText('\n')
 
                 # simulate replacement mode
                 if substring is not None:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2159,6 +2159,10 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                             for i in range(act.count):
                                 cursor.movePosition(
                                     QtGui.QTextCursor.Up)
+                        elif act.dir == 'down':
+                            for i in range(act.count):
+                                cursor.movePosition(
+                                    QtGui.QTextCursor.Down)
                         elif act.dir == 'leftup':
                             for i in range(act.count):
                                 cursor.movePosition(

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2221,7 +2221,8 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
 
                     elif act.action == 'newline':
                         if not cursor.movePosition(QtGui.QTextCursor.NextBlock):
-                            cursor.movePosition(QtGui.QTextCursor.EndOfLine)
+                            cursor.movePosition(QtGui.QTextCursor.EndOfLine,
+                                                QtGui.QTextCursor.MoveAnchor)
                             cursor.insertText('\n')
 
                 # simulate replacement mode

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2220,7 +2220,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                                 QtGui.QTextCursor.MoveAnchor)
 
                     elif act.action == 'newline':
-                        cursor.movePosition(QtGui.QTextCursor.EndOfLine)
+                        if not cursor.movePosition(QtGui.QTextCursor.NextBlock):                            
+                            cursor.movePosition(QtGui.QTextCursor.EndOfLine)
+                            cursor.insertText('\n')
 
                 # simulate replacement mode
                 if substring is not None:

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2154,10 +2154,18 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                             cursor.select(QtGui.QTextCursor.Document)
                             cursor.removeSelectedText()
 
-                    elif act.action == 'move' and act.unit == 'line' and act.dir == 'up':
-                        for i in range(act.count):
+                    elif act.action == 'move' and act.unit == 'line':
+                        if act.dir == 'up':
+                            for i in range(act.count):
+                                cursor.movePosition(
+                                    QtGui.QTextCursor.Up)
+                        elif act.dir == 'leftup':
+                            for i in range(act.count):
+                                cursor.movePosition(
+                                    QtGui.QTextCursor.Up)
                             cursor.movePosition(
-                                QtGui.QTextCursor.Up)
+                            QtGui.QTextCursor.StartOfLine,
+                            QtGui.QTextCursor.MoveAnchor)
 
                     elif act.action == 'carriage-return':
                         cursor.movePosition(

--- a/qtconsole/console_widget.py
+++ b/qtconsole/console_widget.py
@@ -2220,9 +2220,9 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, superQ
                                 QtGui.QTextCursor.MoveAnchor)
 
                     elif act.action == 'newline':
-                        if not cursor.movePosition(QtGui.QTextCursor.NextBlock):                            
-                            cursor.movePosition(QtGui.QTextCursor.EndOfLine)
+                        if not cursor.movePosition(QtGui.QTextCursor.NextBlock):
                             cursor.insertText('\n')
+                            cursor.movePosition(QtGui.QTextCursor.EndOfLine)
 
                 # simulate replacement mode
                 if substring is not None:

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -392,9 +392,9 @@ class TestConsoleWidget(unittest.TestCase):
 
         for text in test_inputs:
             w._append_plain_text(text, before_prompt=True)
-            w._flush_pending_stream() # emulate text being flushed
+            #w._flush_pending_stream() # emulate text being flushed
 
-        self.assert_text_equal(w._get_line_start_cursor(),
+        self.assert_text_equal(w._get_cursor(),
             "Hello\u20290123456789\u2029\u2029prompt>")
 
         # Print after prompt

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -394,7 +394,7 @@ class TestConsoleWidget(unittest.TestCase):
             w._append_plain_text(text, before_prompt=True)
             w._flush_pending_stream() # emulate text being flushed
 
-        self.assert_text_equal(w._get_cursor(),
+        self.assert_text_equal(w._get_line_start_cursor(),
             "Hello\u20290123456789\u2029\u2029prompt>")
 
         # Print after prompt

--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -392,7 +392,7 @@ class TestConsoleWidget(unittest.TestCase):
 
         for text in test_inputs:
             w._append_plain_text(text, before_prompt=True)
-            #w._flush_pending_stream() # emulate text being flushed
+            w._flush_pending_stream() # emulate text being flushed
 
         self.assert_text_equal(w._get_cursor(),
             "Hello\u20290123456789\u2029\u2029prompt>")

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -218,7 +218,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
                 self.assertEqual(action.count, 5)
             else:
                 self.fail('Too many substrings.')
-        self.assertEqual(i, 1, 'Too few substrings.')
+        self.assertEqual(i, 3, 'Too few substrings.')
 
 
 if __name__ == '__main__':

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -139,7 +139,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         for split in self.processor.split_string(string):
             splits.append(split)
             actions.append([action.action for action in self.processor.actions])
-        self.assertEqual(splits, ['foo', None, 'bar', '\r\n', 'cat', '\r\n', '\n'])
+        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, None])
         self.assertEqual(actions, [[], ['carriage-return'], [], ['newline'], [], ['newline'], ['newline']])
 
     def test_beep(self):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -139,7 +139,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         for split in self.processor.split_string(string):
             splits.append(split)
             actions.append([action.action for action in self.processor.actions])
-        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, None])
+        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, '\n'])
         self.assertEqual(actions, [[], ['carriage-return'], [], ['newline'], [], ['newline'], ['newline']])
 
     def test_beep(self):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -139,7 +139,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         for split in self.processor.split_string(string):
             splits.append(split)
             actions.append([action.action for action in self.processor.actions])
-        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, None])
+        self.assertEqual(splits, ['foo', None, 'bar', None, 'cat', None, None])
         self.assertEqual(actions, [[], ['carriage-return'], [], ['newline'], [], ['newline'], ['newline']])
 
     def test_beep(self):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -139,7 +139,7 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         for split in self.processor.split_string(string):
             splits.append(split)
             actions.append([action.action for action in self.processor.actions])
-        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, '\n'])
+        self.assertEqual(splits, ['foo', None, 'bar',None, 'cat', None, None])
         self.assertEqual(actions, [[], ['carriage-return'], [], ['newline'], [], ['newline'], ['newline']])
 
     def test_beep(self):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -183,6 +183,9 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         self.assertEqual(actions, [[], ['carriage-return'], [], ['backspace']])
 
     def test_move_cursor_up(self):
+        """Are the ANSI commands for the cursor movement actions
+        (movement up and to the beginning of the line) processed correctly?
+        """
         string = '\x1b[A\x1b[5A\x1b[F\x1b[5F'
         i = -1
         for i, substring in enumerate(self.processor.split_string(string)):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -186,10 +186,10 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         """Are the ANSI commands for the cursor movement actions
         (movement up and to the beginning of the line) processed correctly?
         """
-        #This line moves the cursor up once, then moves it up five more lines.
-        #Next, it moves the cursor to the beginning of the previous line, and
-        #finally moves it to the beginning of the fifth line above the current 
-        #position
+        # This line moves the cursor up once, then moves it up five more lines.
+        # Next, it moves the cursor to the beginning of the previous line, and
+        # finally moves it to the beginning of the fifth line above the current 
+        # position
         string = '\x1b[A\x1b[5A\x1b[F\x1b[5F'
         i = -1
         for i, substring in enumerate(self.processor.split_string(string)):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -183,8 +183,6 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         self.assertEqual(actions, [[], ['carriage-return'], [], ['backspace']])
 
     def test_move_cursor_up(self):
-        """ Do control sequences for scrolling the buffer work?
-        """
         string = '\x1b[A\x1b[5A\x1b[F\x1b[5F'
         i = -1
         for i, substring in enumerate(self.processor.split_string(string)):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -186,6 +186,10 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         """Are the ANSI commands for the cursor movement actions
         (movement up and to the beginning of the line) processed correctly?
         """
+        #This line moves the cursor up once, then moves it up five more lines.
+        #Next, it moves the cursor to the beginning of the previous line, and
+        #finally moves it to the beginning of the fifth line above the current 
+        #position
         string = '\x1b[A\x1b[5A\x1b[F\x1b[5F'
         i = -1
         for i, substring in enumerate(self.processor.split_string(string)):

--- a/qtconsole/tests/test_ansi_code_processor.py
+++ b/qtconsole/tests/test_ansi_code_processor.py
@@ -182,6 +182,44 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         self.assertEqual(splits, ['abc', None, 'def', None])
         self.assertEqual(actions, [[], ['carriage-return'], [], ['backspace']])
 
+    def test_move_cursor_up(self):
+        """ Do control sequences for scrolling the buffer work?
+        """
+        string = '\x1b[A\x1b[5A\x1b[F\x1b[5F'
+        i = -1
+        for i, substring in enumerate(self.processor.split_string(string)):
+            if i == 0:
+                self.assertEqual(len(self.processor.actions), 1)
+                action = self.processor.actions[0]
+                self.assertEqual(action.action, 'move')
+                self.assertEqual(action.dir, 'up')
+                self.assertEqual(action.unit, 'line')
+                self.assertEqual(action.count, 1)
+            elif i == 1:
+                self.assertEqual(len(self.processor.actions), 1)
+                action = self.processor.actions[0]
+                self.assertEqual(action.action, 'move')
+                self.assertEqual(action.dir, 'up')
+                self.assertEqual(action.unit, 'line')
+                self.assertEqual(action.count, 5)
+            elif i == 2:
+                self.assertEqual(len(self.processor.actions), 1)
+                action = self.processor.actions[0]
+                self.assertEqual(action.action, 'move')
+                self.assertEqual(action.dir, 'leftup')
+                self.assertEqual(action.unit, 'line')
+                self.assertEqual(action.count, 1)
+            elif i == 3:
+                self.assertEqual(len(self.processor.actions), 1)
+                action = self.processor.actions[0]
+                self.assertEqual(action.action, 'move')
+                self.assertEqual(action.dir, 'leftup')
+                self.assertEqual(action.unit, 'line')
+                self.assertEqual(action.count, 5)
+            else:
+                self.fail('Too many substrings.')
+        self.assertEqual(i, 1, 'Too few substrings.')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I made changes to the way the ANSI code \n is handled. Previously, whenever the \n code appeared, a new line was inserted unconditionally. After the change, a new line is inserted unless there is already a written line at the current position. In that case, instead of inserting a new line, the cursor moves one line down.

Preview with changes made:
![image](https://github.com/user-attachments/assets/dd789e51-1003-4002-a971-e5886d8a3ea9)

Comparison of the result obtained with the changes made and in Ipython with QTDM

Preview with changes made:

![PreviewTQDMQtConsole](https://github.com/user-attachments/assets/a23f53b2-bb9a-405d-aea5-0ba43dedeb37)

Preview with IPython:

![PreviewTQDMIpython](https://github.com/user-attachments/assets/c9a06199-2879-4bb1-991d-49a6bb1795b3)


Fixes: #350 
Related with: https://github.com/spyder-ide/spyder-kernels/issues/494 https://github.com/spyder-ide/spyder/issues/6172
