### PR TITLE
IPython pygments lexers are moving to separate package

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -33,6 +33,8 @@ jobs:
         exclude:
           - INSTALL_TYPE: 'conda'
             QT_LIB: 'pyqt6'
+          - INSTALL_TYPE: 'conda'
+            PYTHON_VERSION: '3.8'
     timeout-minutes: 15
     steps:
       - name: Checkout branch

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
     timeout-minutes: 15
     steps:
       - name: Checkout branch

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
     timeout-minutes: 15
     steps:
       - name: Checkout branch

--- a/qtconsole/jupyter_widget.py
+++ b/qtconsole/jupyter_widget.py
@@ -14,7 +14,7 @@ from warnings import warn
 
 from qtpy import QtCore, QtGui
 
-from IPython.lib.lexers import IPython3Lexer
+from ipython_pygments_lexers import IPython3Lexer
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 from qtconsole import __version__

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - jupyter_client
 - pygments
 - ipykernel
+- ipython_pygments_lexers
 
 # For testing
 - coveralls

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_args = dict(
         'jupyter_client>=4.1',
         'pygments',
         'ipykernel>=4.1', # not a real dependency, but require the reference kernel
+        'ipython_pygments_lexers',
         'qtpy>=2.4.0',
         'packaging'
     ],


### PR DESCRIPTION
See https://github.com/ipython/ipython/issues/14520. The newly split package is already available now; I plan to leave the `IPython.lib.lexers` import working for a while, but I thought I'd update this while I'm thinking about it.